### PR TITLE
Implement lobby creation workflow

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -1,12 +1,16 @@
 import { Routes, Route, useParams } from 'react-router-dom';
 import LobbyList from './pages/LobbyList';
 import LobbyRoom from './pages/LobbyRoom';
+import LobbyCreate from './pages/LobbyCreate';
 
 export default function App() {
   return (
     <Routes>
       {/* home = lobby directory */}
       <Route path="/" element={<LobbyList />} />
+
+      {/* create lobby */}
+      <Route path="/create" element={<LobbyCreate />} />
 
       {/* dynamic lobby room */}
       <Route path="/lobbies/:id" element={<LobbyRoomWrapper />} />

--- a/clients/react/src/hooks/useGames.ts
+++ b/clients/react/src/hooks/useGames.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+
+export function useGames() {
+  return useQuery({
+    queryKey: ['games'],
+    queryFn: async () => {
+      const res = await fetch('http://localhost:8000/games');
+      return (await res.json()) as { id: string; name: string }[];
+    },
+  });
+}

--- a/clients/react/src/pages/LobbyCreate.tsx
+++ b/clients/react/src/pages/LobbyCreate.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useGames } from '../hooks/useGames';
+
+export default function LobbyCreate() {
+  const { data: games, isLoading } = useGames();
+  const [gameId, setGameId] = useState('');
+  const navigate = useNavigate();
+
+  const create = async () => {
+    const res = await fetch('http://localhost:8000/lobbies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ gameId }),
+    });
+    const lobby = await res.json();
+    navigate(`/lobbies/${lobby.id}`);
+  };
+
+  if (isLoading) return <p className="p-4">Loading…</p>;
+
+  return (
+    <div className="p-4 space-y-3">
+      <select
+        value={gameId}
+        onChange={e => setGameId(e.target.value)}
+        className="border rounded px-2 py-1"
+      >
+        <option value="">Select a game</option>
+        {games?.map(g => (
+          <option key={g.id} value={g.id}>
+            {g.name}
+          </option>
+        ))}
+      </select>
+      <button
+        disabled={!gameId}
+        onClick={create}
+        className="bg-blue-600 text-white rounded px-3 py-1 disabled:opacity-50"
+      >
+        Create Lobby
+      </button>
+    </div>
+  );
+}

--- a/clients/react/src/pages/LobbyList.tsx
+++ b/clients/react/src/pages/LobbyList.tsx
@@ -6,6 +6,12 @@ export default function LobbyList() {
 
   return (
     <div className="p-4 space-y-2">
+      <a
+        href="/create"
+        className="block bg-green-700/10 rounded-xl p-3 hover:bg-green-700/20"
+      >
+        ➕ Create Lobby
+      </a>
       {data?.map(l => (
         <a
           key={l.id}


### PR DESCRIPTION
## Summary
- list games server-side by reading game manifests
- allow creating lobbies from the React client
- add hook to fetch games
- show "Create Lobby" link on the lobby list

## Testing
- `cargo test --locked --offline` *(fails: no matching package named `dashmap` found)*
- `npm run lint` in `clients/react` *(fails: cannot find package '@eslint/js')*