### PR TITLE
Implement lobby creation workflow

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -1,12 +1,16 @@
 import { Routes, Route, useParams } from 'react-router-dom';
 import LobbyList from './pages/LobbyList';
 import LobbyRoom from './pages/LobbyRoom';
+import LobbyCreate from './pages/LobbyCreate';
 
 export default function App() {
   return (
     <Routes>
       {/* home = lobby directory */}
       <Route path="/" element={<LobbyList />} />
+
+      {/* create lobby */}
+      <Route path="/create" element={<LobbyCreate />} />
 
       {/* dynamic lobby room */}
       <Route path="/lobbies/:id" element={<LobbyRoomWrapper />} />

--- a/clients/react/src/hooks/useGames.ts
+++ b/clients/react/src/hooks/useGames.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+
+export function useGames() {
+  return useQuery({
+    queryKey: ['games'],
+    queryFn: async () => {
+      const res = await fetch('http://localhost:8000/games');
+      return (await res.json()) as { id: string; name: string }[];
+    },
+  });
+}

--- a/clients/react/src/pages/LobbyCreate.tsx
+++ b/clients/react/src/pages/LobbyCreate.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useGames } from '../hooks/useGames';
+
+export default function LobbyCreate() {
+  const { data: games, isLoading } = useGames();
+  const [gameId, setGameId] = useState('');
+  const navigate = useNavigate();
+
+  const create = async () => {
+    const res = await fetch('http://localhost:8000/lobbies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ gameId }),
+    });
+    const lobby = await res.json();
+    navigate(`/lobbies/${lobby.id}`);
+  };
+
+  if (isLoading) return <p className="p-4">Loading…</p>;
+
+  return (
+    <div className="p-4 space-y-4 max-w-md mx-auto">
+      <h1 className="text-2xl font-semibold">Create Lobby</h1>
+      <select
+        value={gameId}
+        onChange={(e) => setGameId(e.target.value)}
+        className="border rounded px-2 py-1 w-full"
+      >
+        <option value="">Select a game</option>
+        {games?.map((g) => (
+          <option key={g.id} value={g.id}>
+            {g.name}
+          </option>
+        ))}
+      </select>
+      <button
+        disabled={!gameId}
+        onClick={create}
+        className="bg-blue-600 text-white rounded px-3 py-1 disabled:opacity-50"
+      >
+        Create Lobby
+      </button>
+    </div>
+  );
+}

--- a/clients/react/src/pages/LobbyList.tsx
+++ b/clients/react/src/pages/LobbyList.tsx
@@ -5,16 +5,25 @@ export default function LobbyList() {
   if (isLoading) return <p className="p-4">Loading…</p>;
 
   return (
-    <div className="p-4 space-y-2">
-      {data?.map(l => (
-        <a
-          key={l.id}
-          href={`/lobbies/${l.id}`}
-          className="block bg-blue-700/10 rounded-xl p-3 hover:bg-blue-700/20"
-        >
-          🎴 {l.game_id} – {l.id.slice(0, 8)}
-        </a>
-      ))}
+    <div className="p-4 space-y-4 max-w-md mx-auto">
+      <h1 className="text-2xl font-semibold">Available Lobbies</h1>
+      <a
+        href="/create"
+        className="block bg-green-700/10 rounded-xl p-3 hover:bg-green-700/20"
+      >
+        ➕ Create Lobby
+      </a>
+      <div className="space-y-2">
+        {data?.map(l => (
+          <a
+            key={l.id}
+            href={`/lobbies/${l.id}`}
+            className="block bg-blue-700/10 rounded-xl p-3 hover:bg-blue-700/20"
+          >
+            🎴 {l.game_id} – {l.id.slice(0, 8)}
+          </a>
+        ))}
+      </div>
     </div>
   );
 }

--- a/clients/react/src/pages/LobbyRoom.tsx
+++ b/clients/react/src/pages/LobbyRoom.tsx
@@ -12,7 +12,8 @@ export default function LobbyRoom({ id }: { id: string }) {
   }, [id]);
 
   return (
-    <div className="p-4 space-y-3">
+    <div className="p-4 space-y-4 max-w-md mx-auto">
+      <h1 className="text-2xl font-semibold">Lobby {id.slice(0, 8)}</h1>
       <button
         className="bg-green-600 text-white rounded px-3 py-1"
         onClick={() => ws?.send('hello')}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -13,3 +13,4 @@ dashmap = "5.5"
 tokio-tungstenite = "0.21"
 tower = "0.5.2"
 tower-http = { version = "0.6.4", features = ["cors"] }
+serde_yaml = "0.9"


### PR DESCRIPTION
## Summary
- list games server-side by reading game manifests
- allow creating lobbies from the React client
- add hook to fetch games
- show "Create Lobby" link on the lobby list
- style lobby pages with headers
- parse manifests using `serde_yaml`

## Testing
- `cargo test --locked --offline` *(fails: no matching package named `axum` found)*
- `npm run lint` in `clients/react` *(fails: cannot find package '@eslint/js')*
