### PR TITLE
Switch lobby state to zustand store

### DIFF
--- a/clients/react/src/store/lobbyStore.ts
+++ b/clients/react/src/store/lobbyStore.ts
@@ -1,0 +1,29 @@
+import { applyPatch } from "fast-json-patch";
+import { create } from "zustand";
+
+export type LobbyStoreState = {
+  bundleMeta?: any;
+  state?: any;
+  setInitialState: (bundleMeta: any, initialState: any) => void;
+  applyDiff: (diff: any[]) => void;
+  reset: () => void;
+};
+
+export const useLobbyStore = create<LobbyStoreState>((set) => ({
+  bundleMeta: undefined,
+  state: undefined,
+  setInitialState: (bundleMeta, initialState) =>
+    set({ bundleMeta, state: initialState }),
+  applyDiff: (diff) =>
+    set((current) => {
+      if (!current.state) return {} as Partial<LobbyStoreState>;
+      const nextState = applyPatch(
+        { ...current.state },
+        diff,
+        true,
+        false
+      ).newDocument;
+      return { state: nextState } as Partial<LobbyStoreState>;
+    }),
+  reset: () => set({ bundleMeta: undefined, state: undefined }),
+}));

--- a/clients/react/src/ws/useLobbyWebSocket.ts
+++ b/clients/react/src/ws/useLobbyWebSocket.ts
@@ -1,14 +1,10 @@
 import { useEffect, useRef, useState, useCallback } from "react";
-import { applyPatch } from "fast-json-patch";
+import { useLobbyStore } from "../store/lobbyStore";
+import { shallow } from "zustand/shallow";
 
 export type WSMessage = {
   direction: "sent" | "received";
   content: string;
-};
-
-type LobbyState = {
-  bundleMeta?: any;
-  state?: any;
 };
 
 export function useLobbyWebSocket(
@@ -16,7 +12,13 @@ export function useLobbyWebSocket(
   playerId: string
 ) {
   const [messages, setMessages] = useState<WSMessage[]>([]);
-  const [lobbyState, setLobbyState] = useState<LobbyState>({});
+  const lobbyState = useLobbyStore(
+    (s) => ({ bundleMeta: s.bundleMeta, state: s.state }),
+    shallow
+  );
+  const setInitialState = useLobbyStore((s) => s.setInitialState);
+  const applyDiff = useLobbyStore((s) => s.applyDiff);
+  const resetLobby = useLobbyStore((s) => s.reset);
   const wsRef = useRef<WebSocket | null>(null);
 
   const sendMessage = useCallback((content: string) => {
@@ -28,7 +30,7 @@ export function useLobbyWebSocket(
 
   useEffect(() => {
     setMessages([]);
-    setLobbyState({});
+    resetLobby();
     const url = `ws://localhost:8000/lobbies/${lobbyId}/ws?player_id=${encodeURIComponent(playerId)}`;
     const ws = new WebSocket(url);
     wsRef.current = ws;
@@ -47,16 +49,9 @@ export function useLobbyWebSocket(
       }
 
       if (data.type === "welcome") {
-        setLobbyState({
-          bundleMeta: data.bundleMeta,
-          state: data.initialState,
-        });
+        setInitialState(data.bundleMeta, data.initialState);
       } else if (data.diff && Array.isArray(data.diff)) {
-        setLobbyState((prev) => {
-          if (!prev.state) return prev; // not initialized yet
-          const nextState = applyPatch({ ...prev.state }, data.diff, true, false).newDocument;
-          return { ...prev, state: nextState };
-        });
+        applyDiff(data.diff);
       }
     };
 


### PR DESCRIPTION
## Summary
- manage lobby state with Zustand
- apply JSON patches from the server using fast-json-patch
- fix infinite rerenders by selecting state with shallow comparison

## Testing
- `npx tsc -p clients/react/tsconfig.app.json --noEmit` *(fails: Cannot find module 'react')*
