### PR TITLE
Add board/turn display

### DIFF
--- a/clients/react/src/components/Board.tsx
+++ b/clients/react/src/components/Board.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+export type BoardProps = {
+  board: (string | null)[][];
+};
+
+const markToGlyph: Record<string, string> = {
+  mark_x: "X",
+  mark_o: "O",
+};
+
+const cellStyle: React.CSSProperties = {
+  width: 60,
+  height: 60,
+  border: "1px solid #333",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  fontSize: 32,
+};
+
+const rowStyle: React.CSSProperties = {
+  display: "flex",
+};
+
+const Cell = React.memo(function Cell({ value }: { value: string | null }) {
+  return <div style={cellStyle}>{value ? markToGlyph[value] ?? value : ""}</div>;
+});
+
+export default function Board({ board }: BoardProps) {
+  if (!board || !Array.isArray(board)) return null;
+  return (
+    <div>
+      {board.map((row, r) => (
+        <div key={r} style={rowStyle}>
+          {row.map((cell, c) => (
+            <Cell key={c} value={cell} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/clients/react/src/components/LobbyView.tsx
+++ b/clients/react/src/components/LobbyView.tsx
@@ -1,6 +1,8 @@
 import { usePlayer } from "../context/PlayerContext";
 import { useLobbyWebSocket } from "../ws/useLobbyWebSocket";
 import { useState } from "react";
+import Board from "./Board";
+import TurnIndicator from "./TurnIndicator";
 
 type Props = {
   lobbyId: string;
@@ -16,6 +18,8 @@ export default function LobbyView({ lobbyId, onLeave }: Props) {
     <div>
       <h2>Lobby {lobbyId}</h2>
       <button onClick={onLeave}>Leave Lobby</button>
+      <TurnIndicator turn={lobbyState.state?.turn} players={lobbyState.state?.players} />
+      <Board board={lobbyState.state?.zones?.board ?? []} />
       <div style={{ marginTop: 32 }}>
         <h3>Current Game State</h3>
         <pre style={{ background: "#eee", padding: 12 }}>

--- a/clients/react/src/components/TurnIndicator.tsx
+++ b/clients/react/src/components/TurnIndicator.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+export type Player = { id: string; mark: string };
+
+const markToGlyph: Record<string, string> = {
+  mark_x: "X",
+  mark_o: "O",
+};
+
+type Props = {
+  turn?: string;
+  players?: Player[];
+};
+
+export default function TurnIndicator({ turn, players }: Props) {
+  if (!turn || !players) return null;
+  const player = players.find(p => p.id === turn);
+  const glyph = player ? markToGlyph[player.mark] : "";
+  return (
+    <div style={{ marginBottom: 16, fontWeight: "bold" }}>
+      Turn: {player ? player.id : turn} {glyph && `(${glyph})`}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a `Board` component for drawing zone grids
- add a `TurnIndicator` component
- show both in the lobby view alongside the JSON state

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*