### PR TITLE
Add lobby list websocket updates

### DIFF
--- a/clients/react/src/components/LobbiesList.tsx
+++ b/clients/react/src/components/LobbiesList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { getLobbies } from "../api/lobbies.ts";
 import type { Lobby } from "../api/lobbies.ts";
+import { useLobbiesWebSocket } from "../ws/useLobbiesWebSocket";
 import CreateLobbyDialog from "./CreateLobbyDialog.tsx";
 
 type Props = {
@@ -13,9 +14,10 @@ export default function LobbiesList({ onLobbySelected }: Props) {
 
   const refresh = () => getLobbies().then(setLobbies);
 
+  useLobbiesWebSocket(setLobbies);
+
   useEffect(() => {
     refresh();
-    // TODO: Better handling of updates, e.g. using WebSocket or polling
   }, []);
 
   return (
@@ -55,7 +57,6 @@ export default function LobbiesList({ onLobbySelected }: Props) {
         <CreateLobbyDialog
           onCreated={(lobby) => {
             setShowDialog(false);
-            refresh();
             onLobbySelected(lobby.id);
           }}
           onCancel={() => setShowDialog(false)}

--- a/clients/react/src/ws/useLobbiesWebSocket.ts
+++ b/clients/react/src/ws/useLobbiesWebSocket.ts
@@ -1,0 +1,15 @@
+import type { Lobby } from "../api/lobbies";
+import { useWebSocket } from "./useWebSocket";
+
+export function useLobbiesWebSocket(onLobbies: (lobbies: Lobby[]) => void) {
+  useWebSocket("ws://localhost:8000/lobbies/ws", data => {
+    try {
+      const parsed = JSON.parse(data);
+      if (Array.isArray(parsed)) {
+        onLobbies(parsed as Lobby[]);
+      }
+    } catch {
+      // ignore invalid JSON
+    }
+  });
+}

--- a/clients/react/src/ws/useLobbyWebSocket.ts
+++ b/clients/react/src/ws/useLobbyWebSocket.ts
@@ -1,10 +1,6 @@
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useState, useCallback } from "react";
 import { applyPatch } from "fast-json-patch";
-
-export type WSMessage = {
-  direction: "sent" | "received";
-  content: string;
-};
+import { useWebSocket, WSMessage } from "./useWebSocket";
 
 type LobbyState = {
   bundleMeta?: any;
@@ -15,66 +11,30 @@ export function useLobbyWebSocket(
   lobbyId: string,
   playerId: string
 ) {
-  const [messages, setMessages] = useState<WSMessage[]>([]);
   const [lobbyState, setLobbyState] = useState<LobbyState>({});
-  const wsRef = useRef<WebSocket | null>(null);
+  const url = `ws://localhost:8000/lobbies/${lobbyId}/ws?player_id=${encodeURIComponent(playerId)}`;
 
-  const sendMessage = useCallback((content: string) => {
-    if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
-      wsRef.current.send(content);
-      setMessages(msgs => [{ direction: "sent", content }, ...msgs]);
+  const { messages, sendMessage } = useWebSocket(url, dataStr => {
+    let data: any;
+    try {
+      data = JSON.parse(dataStr);
+    } catch {
+      return;
     }
-  }, []);
 
-  useEffect(() => {
-    setMessages([]);
-    setLobbyState({});
-    const url = `ws://localhost:8000/lobbies/${lobbyId}/ws?player_id=${encodeURIComponent(playerId)}`;
-    const ws = new WebSocket(url);
-    wsRef.current = ws;
-
-    ws.onopen = () => {
-      // optionally: set connection status
-    };
-
-    ws.onmessage = (event) => {
-      setMessages(msgs => [{ direction: "received", content: event.data }, ...msgs]);
-      let data: any;
-      try {
-        data = JSON.parse(event.data);
-      } catch (err) {
-        return;
-      }
-
-      if (data.type === "welcome") {
-        setLobbyState({
-          bundleMeta: data.bundleMeta,
-          state: data.initialState,
-        });
-      } else if (data.diff && Array.isArray(data.diff)) {
-        setLobbyState((prev) => {
-          if (!prev.state) return prev; // not initialized yet
-          const nextState = applyPatch({ ...prev.state }, data.diff, true, false).newDocument;
-          return { ...prev, state: nextState };
-        });
-      }
-    };
-
-    ws.onerror = (event) => {
-      setMessages(msgs => [
-        ...msgs,
-        { direction: "received", content: "[WebSocket error]: " + event }
-      ]);
-    };
-
-    ws.onclose = () => {
-      // optionally: set connection status
-    };
-
-    return () => {
-      ws.close();
+    if (data.type === "welcome") {
+      setLobbyState({
+        bundleMeta: data.bundleMeta,
+        state: data.initialState,
+      });
+    } else if (data.diff && Array.isArray(data.diff)) {
+      setLobbyState(prev => {
+        if (!prev.state) return prev;
+        const nextState = applyPatch({ ...prev.state }, data.diff, true, false).newDocument;
+        return { ...prev, state: nextState };
+      });
     }
-  }, [lobbyId, playerId]);
+  });
 
   return { messages, sendMessage, lobbyState };
 }

--- a/clients/react/src/ws/useWebSocket.ts
+++ b/clients/react/src/ws/useWebSocket.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef, useCallback, useState } from "react";
+
+export type WSMessage = {
+  direction: "sent" | "received";
+  content: string;
+};
+
+export function useWebSocket(
+  url: string,
+  onMessage: (data: string) => void
+) {
+  const [messages, setMessages] = useState<WSMessage[]>([]);
+  const wsRef = useRef<WebSocket | null>(null);
+
+  const sendMessage = useCallback((content: string) => {
+    if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+      wsRef.current.send(content);
+      setMessages(msgs => [{ direction: "sent", content }, ...msgs]);
+    }
+  }, []);
+
+  useEffect(() => {
+    setMessages([]);
+    const ws = new WebSocket(url);
+    wsRef.current = ws;
+
+    ws.onmessage = (event) => {
+      setMessages(msgs => [{ direction: "received", content: event.data }, ...msgs]);
+      onMessage(event.data);
+    };
+
+    return () => {
+      ws.close();
+    };
+  }, [url, onMessage]);
+
+  return { messages, sendMessage };
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -9,6 +9,8 @@ use uuid::Uuid;
 use tower_http::cors::{CorsLayer, Any};
 use axum::extract::ws::Message;
 use std::sync::Arc;
+use tokio::sync::broadcast;
+use futures_util::StreamExt;
 
 mod bundle;
 mod engine;
@@ -23,12 +25,15 @@ async fn main() -> anyhow::Result<()> {
     
     // Wrap the DashMap in an Arc to ensure proper sharing between requests
     let lobbies = Arc::new(LobbyMap::default());
+    let (lobby_updates_tx, _) = broadcast::channel::<Message>(16);
     
     // Clone for each route handler
     let bundles_for_games = bundles.clone();
     let bundles_for_lobbies = bundles.clone();
     let lobbies_for_lobbies_route = lobbies.clone();
     let lobbies_for_ws = lobbies.clone();
+    let lobby_updates_for_create = lobby_updates_tx.clone();
+    let lobby_updates_for_ws = lobby_updates_tx.clone();
 
     // Improved CORS configuration for WebSocket support
     let cors = CorsLayer::new()
@@ -41,9 +46,17 @@ async fn main() -> anyhow::Result<()> {
     let app = Router::new()
         .route("/games", get(move || list_games(bundles_for_games.clone())))
         .route("/lobbies", post(
-            move |req| create_lobby(req, bundles_for_lobbies.clone(), lobbies.clone())
+            move |req| create_lobby(
+                req,
+                bundles_for_lobbies.clone(),
+                lobbies.clone(),
+                lobby_updates_for_create.clone(),
+            )
         ).get(
             move || list_lobbies(lobbies_for_lobbies_route.clone())
+        ))
+        .route("/lobbies/ws", get(
+            move |ws| lobbies_ws_handler(ws, lobby_updates_for_ws.clone(), lobbies.clone())
         ))
         .route("/lobbies/:id/ws", get(
             move |path, ws, query| ws_handler(path, ws, query, lobbies_for_ws.clone())
@@ -64,6 +77,7 @@ async fn create_lobby(
     Json(req): Json<serde_json::Value>,
     bundles: BundleMap,
     lobbies: Arc<LobbyMap>,
+    lobby_updates: broadcast::Sender<Message>,
 ) -> impl IntoResponse {
     let game_id = req["gameId"].as_str().unwrap_or("tic-tac-toe");
     let bundle = match bundles.get_latest(game_id) {
@@ -79,7 +93,11 @@ async fn create_lobby(
     println!("[HTTP] Creating new lobby: {} for game: {}", id, game_id);
     
     lobbies.insert(id.clone(), new_lobby(id.clone(), bundle));
-    
+
+    // broadcast updated lobby list
+    let list = current_lobbies_json(&lobbies);
+    let _ = lobby_updates.send(Message::Text(list.to_string()));
+
     Json(serde_json::json!({ "id": id, "game_id": game_id }))
 }
 
@@ -116,6 +134,49 @@ async fn list_games(
     }).collect::<Vec<_>>();
     
     Json(game_list)
+}
+
+fn current_lobbies_json(lobbies: &LobbyMap) -> serde_json::Value {
+    let list = lobbies
+        .iter()
+        .map(|l| {
+            let lobby = l.value();
+            serde_json::json!({
+                "id": l.key(),
+                "game_id": lobby.bundle.game_id,
+                "name": format!("{} - Lobby {}", lobby.bundle.game_id, &l.key()[0..6]),
+                "players": lobby.player_list(),
+                "started": lobby.is_started()
+            })
+        })
+        .collect::<Vec<_>>();
+    serde_json::Value::Array(list)
+}
+
+async fn lobbies_ws_handler(
+    ws: WebSocketUpgrade,
+    lobby_updates: broadcast::Sender<Message>,
+    lobbies: Arc<LobbyMap>,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| async move {
+        let (mut tx, mut rx) = socket.split();
+
+        // send initial lobby list
+        let list = current_lobbies_json(&lobbies);
+        let _ = tx.send(Message::Text(list.to_string())).await;
+
+        let mut updates = lobby_updates.subscribe();
+        tokio::spawn(async move {
+            while let Ok(msg) = updates.recv().await {
+                if tx.send(msg.clone()).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        // ignore incoming messages
+        while let Some(Ok(_)) = rx.next().await {}
+    })
 }
 
 /* ---------- WS ---------- */


### PR DESCRIPTION
## Summary
- broadcast lobby updates from the server
- expose `/lobbies/ws` for lobby list subscription
- reuse WebSocket hook and add new hooks for lobby list
- update lobby list component to subscribe to updates

## Testing
- `cargo check` *(fails: Could not connect to server)*
- `npx tsc -p clients/react/tsconfig.app.json` *(fails: missing dependencies)*