### PR TITLE
Add player perspective to TurnIndicator

### DIFF
--- a/clients/react/src/components/LobbyView.tsx
+++ b/clients/react/src/components/LobbyView.tsx
@@ -25,7 +25,11 @@ export default function LobbyView({ lobbyId, onLeave }: Props) {
         </div>
         
         <div className="space-y-4">
-          <TurnIndicator turn={lobbyState.state?.turn} players={lobbyState.state?.players} />
+          <TurnIndicator
+            you={lobbyState.you}
+            turn={lobbyState.state?.turn}
+            players={lobbyState.state?.players}
+          />
           <Board board={lobbyState.state?.zones?.board ?? []} />
         </div>
       </div>

--- a/clients/react/src/components/TurnIndicator.tsx
+++ b/clients/react/src/components/TurnIndicator.tsx
@@ -8,17 +8,21 @@ const markToGlyph: Record<string, string> = {
 };
 
 type Props = {
+  you?: string;
   turn?: string;
   players?: Player[];
 };
 
-export default function TurnIndicator({ turn, players }: Props) {
+export default function TurnIndicator({ you, turn, players }: Props) {
   if (!turn || !players) return null;
   const player = players.find(p => p.id === turn);
   const glyph = player ? markToGlyph[player.mark] : "";
+  const label = you && you === turn
+    ? `It is your turn`
+    : `It is ${player ? player.id : turn}'s turn`;
   return (
     <div style={{ marginBottom: 16, fontWeight: "bold" }}>
-      Turn: {player ? player.id : turn} {glyph && `(${glyph})`}
+      {label} {glyph && `(${glyph})`}
     </div>
   );
 }

--- a/clients/react/src/ws/useLobbyWebSocket.ts
+++ b/clients/react/src/ws/useLobbyWebSocket.ts
@@ -3,6 +3,7 @@ import { applyPatch } from "fast-json-patch";
 import { useWebSocket, type WSMessage } from "./useWebSocket";
 
 type LobbyState = {
+  you?: string;
   meta?: any;
   state?: any;
 };
@@ -24,6 +25,7 @@ export function useLobbyWebSocket(
 
     if (data.type === "welcome") {
       setLobbyState({
+        you: data.you,
         meta: data.meta,
         state: data.state,
       });


### PR DESCRIPTION
## Summary
- keep track of the `you` property from welcome frames
- show personalized turn information in `TurnIndicator`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*