### PR TITLE
Add player perspective to TurnIndicator

### DIFF
--- a/clients/react/src/components/LobbiesList.tsx
+++ b/clients/react/src/components/LobbiesList.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { getLobbies } from "../api/lobbies.ts";
 import type { Lobby } from "../api/lobbies.ts";
-import { useLobbiesWebSocket } from "../ws/useLobbiesWebSocket";
+import { useLobbyListSocket } from "../ws/useLobbyListSocket";
 import CreateLobbyDialog from "./CreateLobbyDialog.tsx";
 
 type Props = {
@@ -14,7 +14,7 @@ export default function LobbiesList({ onLobbySelected }: Props) {
 
   const refresh = () => getLobbies().then(setLobbies);
 
-  useLobbiesWebSocket(setLobbies);
+  useLobbyListSocket(setLobbies);
 
   useEffect(() => {
     refresh();

--- a/clients/react/src/components/LobbyView.tsx
+++ b/clients/react/src/components/LobbyView.tsx
@@ -1,5 +1,5 @@
 import { usePlayer } from "../context/PlayerContext";
-import { useLobbyWebSocket } from "../ws/useLobbyWebSocket";
+import { useLobbySocket } from "../ws/useLobbySocket";
 import { useState } from "react";
 import Board from "./Board";
 import TurnIndicator from "./TurnIndicator";
@@ -12,7 +12,7 @@ type Props = {
 export default function LobbyView({ lobbyId, onLeave }: Props) {
   const { player } = usePlayer();
   const [input, setInput] = useState("");
-  const { messages, sendMessage, lobbyState } = useLobbyWebSocket(lobbyId, player!.username);
+  const { messages, sendMessage, lobbyState } = useLobbySocket(lobbyId, player!.username);
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl space-y-6">
@@ -25,7 +25,11 @@ export default function LobbyView({ lobbyId, onLeave }: Props) {
         </div>
         
         <div className="space-y-4">
-          <TurnIndicator turn={lobbyState.state?.turn} players={lobbyState.state?.players} />
+          <TurnIndicator
+            you={lobbyState.you}
+            turn={lobbyState.state?.turn}
+            players={lobbyState.state?.players}
+          />
           <Board board={lobbyState.state?.zones?.board ?? []} />
         </div>
       </div>

--- a/clients/react/src/components/TurnIndicator.tsx
+++ b/clients/react/src/components/TurnIndicator.tsx
@@ -8,17 +8,21 @@ const markToGlyph: Record<string, string> = {
 };
 
 type Props = {
+  you?: string;
   turn?: string;
   players?: Player[];
 };
 
-export default function TurnIndicator({ turn, players }: Props) {
+export default function TurnIndicator({ you, turn, players }: Props) {
   if (!turn || !players) return null;
   const player = players.find(p => p.id === turn);
   const glyph = player ? markToGlyph[player.mark] : "";
+  const label = you && you === turn
+    ? `It is your turn`
+    : `It is ${player ? player.id : turn}'s turn`;
   return (
     <div style={{ marginBottom: 16, fontWeight: "bold" }}>
-      Turn: {player ? player.id : turn} {glyph && `(${glyph})`}
+      {label} {glyph && `(${glyph})`}
     </div>
   );
 }

--- a/clients/react/src/ws/useLobbyListSocket.ts
+++ b/clients/react/src/ws/useLobbyListSocket.ts
@@ -1,7 +1,7 @@
 import type { Lobby } from "../api/lobbies";
 import { useWebSocket } from "./useWebSocket";
 
-export function useLobbiesWebSocket(onLobbies: (lobbies: Lobby[]) => void) {
+export function useLobbyListSocket(onLobbies: (lobbies: Lobby[]) => void) {
   useWebSocket("ws://localhost:8000/lobbies/ws", data => {
     try {
       const parsed = JSON.parse(data);

--- a/clients/react/src/ws/useLobbySocket.ts
+++ b/clients/react/src/ws/useLobbySocket.ts
@@ -3,11 +3,12 @@ import { applyPatch } from "fast-json-patch";
 import { useWebSocket, type WSMessage } from "./useWebSocket";
 
 type LobbyState = {
+  you?: string;
   meta?: any;
   state?: any;
 };
 
-export function useLobbyWebSocket(
+export function useLobbySocket(
   lobbyId: string,
   playerId: string
 ) {
@@ -24,6 +25,7 @@ export function useLobbyWebSocket(
 
     if (data.type === "welcome") {
       setLobbyState({
+        you: data.you,
         meta: data.meta,
         state: data.state,
       });

--- a/server/src/lobby.rs
+++ b/server/src/lobby.rs
@@ -69,6 +69,15 @@ impl Lobby {
         players.clone()
     }
 
+    /// Map a player username to their actor ID (p1, p2, ...)
+    fn actor_for_player(&self, player_id: &str) -> Option<String> {
+        let players = self.players.lock();
+        players
+            .iter()
+            .position(|p| p == player_id)
+            .map(|idx| format!("p{}", idx + 1))
+    }
+
     pub fn add_player(&self, player_id: String) -> bool {
         let mut players = self.players.lock();
         
@@ -177,9 +186,10 @@ impl Lobby {
                 };
 
                 let possible = Lobby::possible_verbs(&snapshot);
+                let actor = self.actor_for_player(&player_id);
                 let welcome = serde_json::json!({
                     "type": "welcome",
-                    "you": player_id,
+                    "you": actor,
                     "state": snapshot,
                     "meta": { "possibleVerbs": possible }
                 });
@@ -226,9 +236,10 @@ impl Lobby {
                             guard.clone()
                         };
                         let possible = Lobby::possible_verbs(&snapshot);
+                        let actor = self_clone.actor_for_player(&player_id_clone);
                         let welcome = serde_json::json!({
                             "type": "welcome",
-                            "you": player_id_clone,
+                            "you": actor,
                             "state": snapshot,
                             "meta": { "possibleVerbs": possible }
                         });


### PR DESCRIPTION
## Summary
- keep track of the `you` property from welcome frames
- show personalized turn information in `TurnIndicator`
- rename lobby websocket hooks for clarity
- send actor IDs (`p1`, `p2`) in server welcome frames

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*