### PR TITLE
Add actor mapping for personalized turns

### DIFF
--- a/clients/react/src/components/LobbyView.tsx
+++ b/clients/react/src/components/LobbyView.tsx
@@ -25,7 +25,11 @@ export default function LobbyView({ lobbyId, onLeave }: Props) {
         </div>
         
         <div className="space-y-4">
-          <TurnIndicator turn={lobbyState.state?.turn} players={lobbyState.state?.players} />
+          <TurnIndicator
+            you={lobbyState.you}
+            turn={lobbyState.state?.turn}
+            players={lobbyState.state?.players}
+          />
           <Board board={lobbyState.state?.zones?.board ?? []} />
         </div>
       </div>

--- a/clients/react/src/components/TurnIndicator.tsx
+++ b/clients/react/src/components/TurnIndicator.tsx
@@ -8,17 +8,21 @@ const markToGlyph: Record<string, string> = {
 };
 
 type Props = {
+  you?: string;
   turn?: string;
   players?: Player[];
 };
 
-export default function TurnIndicator({ turn, players }: Props) {
+export default function TurnIndicator({ you, turn, players }: Props) {
   if (!turn || !players) return null;
   const player = players.find(p => p.id === turn);
-  const glyph = player ? markToGlyph[player.mark] : "";
+  const glyph = player ? markToGlyph[player.mark] ?? player.mark : "";
+  const label = you && you === turn
+    ? `It is your turn`
+    : `It is ${player ? player.id : turn}'s turn`;
   return (
     <div style={{ marginBottom: 16, fontWeight: "bold" }}>
-      Turn: {player ? player.id : turn} {glyph && `(${glyph})`}
+      {label} {glyph && `(${glyph})`}
     </div>
   );
 }

--- a/clients/react/src/ws/useLobbyWebSocket.ts
+++ b/clients/react/src/ws/useLobbyWebSocket.ts
@@ -3,6 +3,7 @@ import { applyPatch } from "fast-json-patch";
 import { useWebSocket, type WSMessage } from "./useWebSocket";
 
 type LobbyState = {
+  you?: string;
   meta?: any;
   state?: any;
 };
@@ -24,6 +25,7 @@ export function useLobbyWebSocket(
 
     if (data.type === "welcome") {
       setLobbyState({
+        you: data.you,
         meta: data.meta,
         state: data.state,
       });
@@ -31,7 +33,7 @@ export function useLobbyWebSocket(
       setLobbyState(prev => {
         const full = { meta: prev.meta, state: prev.state };
         const patched = applyPatch({ ...full }, data.patch, true, false).newDocument as LobbyState;
-        return patched;
+        return { ...patched, you: prev.you };
       });
     }
   });

--- a/server/src/lobby.rs
+++ b/server/src/lobby.rs
@@ -69,6 +69,15 @@ impl Lobby {
         players.clone()
     }
 
+    /// Map a player's username to their actor ID ("p1" or "p2")
+    fn actor_for_player(&self, username: &str) -> Option<String> {
+        let players = self.players.lock();
+        players
+            .iter()
+            .position(|p| p == username)
+            .map(|idx| format!("p{}", idx + 1))
+    }
+
     pub fn add_player(&self, player_id: String) -> bool {
         let mut players = self.players.lock();
         
@@ -162,6 +171,7 @@ impl Lobby {
         // --- 1️⃣ send welcome message regardless of game state ------------------------------------
         let is_game_started = *self.game_started.lock();
         let player_id = self.players.lock().last().cloned().unwrap_or_else(|| "unknown".to_string());
+        let actor_id = self.actor_for_player(&player_id).unwrap_or_else(|| "spectator".to_string());
         
         println!("[Socket] WebSocket client connected for player: {}", player_id);
         
@@ -179,7 +189,7 @@ impl Lobby {
                 let possible = Lobby::possible_verbs(&snapshot);
                 let welcome = serde_json::json!({
                     "type": "welcome",
-                    "you": player_id,
+                    "you": actor_id,
                     "state": snapshot,
                     "meta": { "possibleVerbs": possible }
                 });
@@ -209,6 +219,7 @@ impl Lobby {
             let mut rx = self.tx.subscribe();
             let sink_clone = sink.clone();
             let player_id_clone = player_id.clone();
+            let actor_clone = self.actor_for_player(&player_id).unwrap_or_else(|| "spectator".to_string());
             let self_clone = self.clone();
             
             // Set up forward task
@@ -228,7 +239,7 @@ impl Lobby {
                         let possible = Lobby::possible_verbs(&snapshot);
                         let welcome = serde_json::json!({
                             "type": "welcome",
-                            "you": player_id_clone,
+                            "you": actor_clone,
                             "state": snapshot,
                             "meta": { "possibleVerbs": possible }
                         });


### PR DESCRIPTION
## Summary
- map usernames to actor IDs on the server
- send the actor ID in welcome messages
- preserve the `you` field when applying diffs
- support fallback glyphs in `TurnIndicator`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*