### PR TITLE
Add lobby join/leave and persistent player

### DIFF
--- a/clients/react/src/api/lobbies.ts
+++ b/clients/react/src/api/lobbies.ts
@@ -1,6 +1,9 @@
 export type Lobby = {
   id: string;
   game_id: string;
+  name: string;
+  players: string[];
+  started: boolean;
 };
 
 export async function getLobbies(): Promise<Lobby[]> {

--- a/clients/react/src/components/LobbiesList.tsx
+++ b/clients/react/src/components/LobbiesList.tsx
@@ -3,6 +3,7 @@ import { getLobbies } from "../api/lobbies.ts";
 import type { Lobby } from "../api/lobbies.ts";
 import { useLobbiesWebSocket } from "../ws/useLobbiesWebSocket";
 import CreateLobbyDialog from "./CreateLobbyDialog.tsx";
+import { usePlayer } from "../context/PlayerContext.tsx";
 
 type Props = {
   onLobbySelected: (lobbyId: string) => void;
@@ -11,6 +12,7 @@ type Props = {
 export default function LobbiesList({ onLobbySelected }: Props) {
   const [lobbies, setLobbies] = useState<Lobby[]>([]);
   const [showDialog, setShowDialog] = useState(false);
+  const { player } = usePlayer();
 
   const refresh = () => getLobbies().then(setLobbies);
 
@@ -39,14 +41,16 @@ export default function LobbiesList({ onLobbySelected }: Props) {
           {lobbies.map((lobby) => (
             <li key={lobby.id} className="bg-gray-700 rounded-lg p-4 flex justify-between items-center">
               <div>
-                <h3 className="font-medium">Lobby {lobby.id}</h3>
+                <h3 className="font-medium">{lobby.name}</h3>
                 <p className="text-sm text-gray-400">Game: {lobby.game_id}</p>
+                <p className="text-sm text-gray-400">Players: {lobby.players.map(p => p === player?.username ? `${p} (you)` : p).join(", ") || "None"}</p>
+                <p className="text-sm text-gray-400">Status: {lobby.started ? "Started" : (lobby.players.length >= 2 ? "Not Started" : "Waiting for Players")}</p>
               </div>
               <button
                 onClick={() => onLobbySelected(lobby.id)}
                 className="btn btn-secondary"
               >
-                Join Lobby
+                Open Lobby
               </button>
             </li>
           ))}

--- a/clients/react/src/components/LobbyView.tsx
+++ b/clients/react/src/components/LobbyView.tsx
@@ -12,7 +12,8 @@ type Props = {
 export default function LobbyView({ lobbyId, onLeave }: Props) {
   const { player } = usePlayer();
   const [input, setInput] = useState("");
-  const { messages, sendMessage, lobbyState } = useLobbyWebSocket(lobbyId, player!.username);
+  const { messages, sendMessage, lobbyState, joinLobby, leaveLobby, startGame } = useLobbyWebSocket(lobbyId, player!.username, false);
+  const joined = lobbyState.you && lobbyState.you !== "spectator";
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl space-y-6">
@@ -20,11 +21,19 @@ export default function LobbyView({ lobbyId, onLeave }: Props) {
         <div className="flex justify-between items-center mb-6">
           <h2 className="text-2xl font-bold">Lobby {lobbyId}</h2>
           <button onClick={onLeave} className="btn btn-secondary">
-            Leave Lobby
+            Back to Lobbies
           </button>
         </div>
-        
+
         <div className="space-y-4">
+          {joined ? (
+            <button onClick={leaveLobby} className="btn btn-secondary">Leave Game</button>
+          ) : (
+            <button onClick={joinLobby} className="btn btn-primary">Join Game</button>
+          )}
+          {joined && !lobbyState.started && lobbyState.state && (
+            <button onClick={startGame} className="btn btn-primary ml-2">Start Game</button>
+          )}
           <TurnIndicator
             you={lobbyState.you}
             turn={lobbyState.state?.turn}

--- a/clients/react/src/context/PlayerContext.tsx
+++ b/clients/react/src/context/PlayerContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, ReactNode } from "react";
+import React, { createContext, useContext, useState, useEffect, ReactNode } from "react";
 
 type Player = {
   username: string;
@@ -13,7 +13,15 @@ type PlayerContextType = {
 const PlayerContext = createContext<PlayerContextType | undefined>(undefined);
 
 export const PlayerProvider = ({ children }: { children: ReactNode }) => {
-  const [player, setPlayer] = useState<Player | null>(null);
+  const [player, setPlayer] = useState<Player | null>(() => {
+    const stored = localStorage.getItem("player");
+    return stored ? JSON.parse(stored) : null;
+  });
+
+  useEffect(() => {
+    if (player) localStorage.setItem("player", JSON.stringify(player));
+    else localStorage.removeItem("player");
+  }, [player]);
 
   const login = (username: string) => setPlayer({ username });
   const logout = () => setPlayer(null);

--- a/clients/react/src/ws/useLobbyWebSocket.ts
+++ b/clients/react/src/ws/useLobbyWebSocket.ts
@@ -1,19 +1,22 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { applyPatch } from "fast-json-patch";
 import { useWebSocket, type WSMessage } from "./useWebSocket";
 
-type LobbyState = {
+export type LobbyState = {
   you?: string;
   meta?: any;
   state?: any;
+  started?: boolean;
 };
 
 export function useLobbyWebSocket(
   lobbyId: string,
-  playerId: string
+  playerId: string,
+  autoJoin: boolean
 ) {
   const [lobbyState, setLobbyState] = useState<LobbyState>({});
-  const url = `ws://localhost:8000/lobbies/${lobbyId}/ws?player_id=${encodeURIComponent(playerId)}`;
+  const [lastTick, setLastTick] = useState(() => Number(localStorage.getItem(`lobby_${lobbyId}_lastTick`) || "0"));
+  const url = `ws://localhost:8000/lobbies/${lobbyId}/ws?player_id=${encodeURIComponent(playerId)}&join=${autoJoin ? 1 : 0}&since=${lastTick}`;
 
   const { messages, sendMessage } = useWebSocket(url, dataStr => {
     let data: any;
@@ -28,15 +31,28 @@ export function useLobbyWebSocket(
         you: data.you,
         meta: data.meta,
         state: data.state,
+        started: data.started,
       });
+      if (typeof data.tick === "number") setLastTick(data.tick);
     } else if (data.type === "diff" && Array.isArray(data.patch)) {
       setLobbyState(prev => {
         const full = { meta: prev.meta, state: prev.state };
         const patched = applyPatch({ ...full }, data.patch, true, false).newDocument as LobbyState;
-        return { ...patched, you: prev.you };
+        return { ...patched, you: prev.you, started: prev.started };
       });
+      if (typeof data.tick === "number") setLastTick(data.tick);
     }
   });
 
-  return { messages, sendMessage, lobbyState };
+  useEffect(() => {
+    return () => {
+      localStorage.setItem(`lobby_${lobbyId}_lastTick`, String(lastTick));
+    };
+  }, [lastTick, lobbyId]);
+
+  const joinLobby = () => sendMessage(JSON.stringify({ action: "join" }));
+  const leaveLobby = () => sendMessage(JSON.stringify({ action: "leave" }));
+  const startGame = () => sendMessage(JSON.stringify({ action: "start_game" }));
+
+  return { messages, sendMessage, lobbyState, joinLobby, leaveLobby, startGame };
 }

--- a/server/src/lobby.rs
+++ b/server/src/lobby.rs
@@ -15,8 +15,30 @@ pub type LobbyMap = DashMap<String, Arc<Lobby>>;
 /* --------------------------------------------------------------------------
    constructor helper
    ----------------------------------------------------------------------- */
-pub fn new_lobby(id: String, bundle: Bundle) -> Arc<Lobby> {
-    Arc::new(Lobby::new(id, bundle))
+pub fn new_lobby(
+    id: String,
+    bundle: Bundle,
+    lobbies: Arc<LobbyMap>,
+    lobby_updates: broadcast::Sender<Message>,
+) -> Arc<Lobby> {
+    Arc::new(Lobby::new(id, bundle, lobbies, lobby_updates))
+}
+
+pub fn current_lobbies_json(lobbies: &LobbyMap) -> serde_json::Value {
+    let list = lobbies
+        .iter()
+        .map(|l| {
+            let lobby = l.value();
+            serde_json::json!({
+                "id": l.key(),
+                "game_id": lobby.bundle.game_id,
+                "name": format!("{} - Lobby {}", lobby.bundle.game_id, &l.key()[0..6]),
+                "players": lobby.player_list(),
+                "started": lobby.is_started()
+            })
+        })
+        .collect::<Vec<_>>();
+    serde_json::Value::Array(list)
 }
 
 /* --------------------------------------------------------------------------
@@ -40,10 +62,24 @@ pub struct Lobby {
 
     /// Incrementing tick for diff frames
     tick: Mutex<u64>,
+
+    /// Stored diff history
+    history: Mutex<Vec<serde_json::Value>>,
+
+    /// Sender for lobby list updates
+    lobby_updates: broadcast::Sender<Message>,
+
+    /// Reference to lobby map for updates
+    lobbies: Arc<LobbyMap>,
 }
 
 impl Lobby {
-    pub fn new(id: String, bundle: Bundle) -> Self {
+    pub fn new(
+        id: String,
+        bundle: Bundle,
+        lobbies: Arc<LobbyMap>,
+        lobby_updates: broadcast::Sender<Message>,
+    ) -> Self {
         let initial = engine::load_initial_state(&bundle);
         let (tx, _) = broadcast::channel(64);
         Self {
@@ -54,7 +90,15 @@ impl Lobby {
             players: Mutex::new(Vec::new()),
             game_started: Mutex::new(false),
             tick: Mutex::new(0),
+            history: Mutex::new(Vec::new()),
+            lobby_updates,
+            lobbies,
         }
+    }
+
+    fn broadcast_lobby_list(&self) {
+        let list = current_lobbies_json(&self.lobbies);
+        let _ = self.lobby_updates.send(Message::Text(list.to_string()));
     }
 
     pub fn players(&self) -> usize {
@@ -91,11 +135,8 @@ impl Lobby {
         if players.len() < 2 {
             println!("[Socket] Adding new player {} to the lobby", player_id);
             players.push(player_id);
-            // If we now have 2 players, start the game
-            if players.len() == 2 {
-                *self.game_started.lock() = true;
-                println!("[Socket] Two players joined, starting the game!");
-            }
+            drop(players);
+            self.broadcast_lobby_list();
             return true;
         }
         
@@ -108,9 +149,11 @@ impl Lobby {
         let mut players = self.players.lock();
         let before_len = players.len();
         players.retain(|id| id != player_id);
-        
+
         if players.len() < before_len {
             println!("[Socket] Player {} removed from lobby", player_id);
+            drop(players);
+            self.broadcast_lobby_list();
             return true;
         }
         
@@ -162,336 +205,89 @@ impl Lobby {
         *self.game_started.lock()
     }
 
-    /// Accept a new WebSocket client, drive send/recv loops.
-    pub async fn accept_client(self: Arc<Self>, socket: WebSocket) {
-        // --- split socket ---------------------------------------------------
-        let (sink_raw, mut stream) = socket.split();
-        let sink = Arc::new(TokioMutex::new(sink_raw)); // make clonable
-        
-        // --- 1️⃣ send welcome message regardless of game state ------------------------------------
-        let is_game_started = *self.game_started.lock();
-        let player_id = self.players.lock().last().cloned().unwrap_or_else(|| "unknown".to_string());
-        let actor_id = self.actor_for_player(&player_id).unwrap_or_else(|| "spectator".to_string());
-        
-        println!("[Socket] WebSocket client connected for player: {}", player_id);
-        
-        // Send information about lobby state first
+pub fn start_game(&self) {
+    *self.game_started.lock() = true;
+    self.broadcast_lobby_list();
+}
+
+/// Accept a new WebSocket client, drive send/recv loops.
+    pub async fn accept_client(self: Arc<Self>, socket: WebSocket, player_id: String, join: bool, since: u64) {
+        let (mut tx, mut rx) = socket.split();
+        if join {
+            self.add_player(player_id.clone());
+        }
+
+        if self.is_started() {
+            let snapshot = { let g = self.state.lock(); g.clone() };
+            let possible = Lobby::possible_verbs(&snapshot);
+            let actor = self.actor_for_player(&player_id).unwrap_or_else(|| "spectator".to_string());
+            let welcome = serde_json::json!({
+                "type":"welcome",
+                "you": actor,
+                "started": self.is_started(),
+                "state": snapshot,
+                "meta": {"possibleVerbs": possible}
+            });
+            let _ = tx.send(Message::Text(welcome.to_string())).await;
+        } else {
+            let waiting = serde_json::json!({"type":"info","message":"Waiting for another player..."});
+            let _ = tx.send(Message::Text(waiting.to_string())).await;
+        }
+
         {
-            let mut locked = sink.lock().await;
-            
-            if is_game_started {
-                // Game has started, send the full game state
-                let snapshot = {
-                    let guard = self.state.lock();
-                    guard.clone()
-                };
-
-                let possible = Lobby::possible_verbs(&snapshot);
-                let welcome = serde_json::json!({
-                    "type": "welcome",
-                    "you": actor_id,
-                    "state": snapshot,
-                    "meta": { "possibleVerbs": possible }
-                });
-
-                println!("[Socket] Sending welcome message to player: {}", player_id);
-                if let Err(e) = locked.send(Message::Text(welcome.to_string())).await {
-                    println!("[Socket] ERROR: Error sending welcome message: {}", e);
-                    return;
-                }
-            } else {
-                // Game not started yet, send waiting message
-                let waiting_msg = serde_json::json!({
-                    "type": "info",
-                    "message": "Waiting for another player to join..."
-                });
-                println!("[Socket] Sending waiting message to player: {}", player_id);
-                if let Err(e) = locked.send(Message::Text(waiting_msg.to_string())).await {
-                    println!("[Socket] ERROR: Error sending waiting message: {}", e);
-                    return;
+            let history = self.history.lock();
+            for frame in history.iter() {
+                if frame["tick"].as_u64().unwrap_or(0) > since {
+                    let _ = tx.send(Message::Text(frame.to_string())).await;
                 }
             }
         }
 
-        /* spawn task to forward broadcast events */
-        let forward_handle;
-        {
-            let mut rx = self.tx.subscribe();
-            let sink_clone = sink.clone();
-            let player_id_clone = player_id.clone();
-            let actor_clone = self.actor_for_player(&player_id).unwrap_or_else(|| "spectator".to_string());
-            let self_clone = self.clone();
-            
-            // Set up forward task
-            forward_handle = tokio::spawn(async move {
-                // Also watch for game start
-                let mut last_game_started = is_game_started;
-                
-                loop {
-                    // Check if game started state changed
-                    let curr_game_started = *self_clone.game_started.lock();
-                    if !last_game_started && curr_game_started {
-                        // Game just started, send welcome message with game state
-                        let snapshot = {
-                            let guard = self_clone.state.lock();
-                            guard.clone()
-                        };
-                        let possible = Lobby::possible_verbs(&snapshot);
-                        let welcome = serde_json::json!({
-                            "type": "welcome",
-                            "you": actor_clone,
-                            "state": snapshot,
-                            "meta": { "possibleVerbs": possible }
-                        });
-                        
-                        // Use a different approach to avoid borrow checker issues
-                        let sink_for_welcome = sink_clone.clone();
-                        let lock_attempt = tokio::time::timeout(
-                            tokio::time::Duration::from_millis(500), 
-                            sink_for_welcome.lock()
-                        ).await;
-                        
-                        match lock_attempt {
-                            Ok(mut locked) => {
-                                println!("[Socket] Game started! Sending welcome message to player: {}", player_id_clone);
-                                if let Err(e) = locked.send(Message::Text(welcome.to_string())).await {
-                                    println!("[Socket] ERROR: Error sending welcome message on game start: {}", e);
-                                    return;
-                                }
-                                
-                                last_game_started = curr_game_started;
-                            },
-                            Err(_) => {
-                                println!("[Socket] ERROR: Timeout acquiring lock for welcome message to player: {}", player_id_clone);
-                                return;
-                            }
-                        }
-                    }
-                    
-                    // Wait for messages or timeout
-                    tokio::select! {
-                        Ok(msg) = rx.recv() => {
-                            // Use a different approach to avoid borrow checker issues
-                            let sink_for_broadcast = sink_clone.clone();
-                            
-                            // Do the timeout separately
-                            let lock_attempt = tokio::time::timeout(
-                                tokio::time::Duration::from_millis(500),
-                                sink_for_broadcast.lock()
-                            ).await;
-                            
-                            // Handle the result
-                            match lock_attempt {
-                                Ok(mut locked) => {
-                                    if let Err(e) = locked.send(msg).await {
-                                        println!("[Socket] ERROR: Error forwarding message to client: {}", e);
-                                        return;
-                                    }
-                                },
-                                Err(_) => {
-                                    println!("[Socket] ERROR: Timeout acquiring lock for broadcast");
-                                    return;
-                                }
-                            }
-                        },
-                        _ = tokio::time::sleep(tokio::time::Duration::from_secs(1)) => {
-                            // Periodic check for game start
-                        }
-                    }
-                }
-            });
-        }
-
-        // Send periodic pings to keep the connection alive
-        let sink_for_ping = sink.clone();
-        let player_id_for_ping = player_id.clone();
-        let ping_handle = tokio::spawn(async move {
-            // Use a shorter interval to prevent timeouts
-            let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(15));
-            
-            // Track failed attempts
-            let mut consecutive_failures = 0;
-            
-            loop {
-                interval.tick().await;
-                
-                // Generate a ping message with current timestamp
-                let ping_msg = serde_json::json!({
-                    "type": "ping",
-                    "timestamp": chrono::Utc::now().timestamp()
-                });
-                
-                // Restructure to fix borrowing issue
-                let sink_for_ping_temp = sink_for_ping.clone();
-                
-                // Do the timeout separately to avoid borrow checker issues
-                let lock_attempt = tokio::time::timeout(
-                    tokio::time::Duration::from_millis(500),
-                    sink_for_ping_temp.lock()
-                ).await;
-                
-                match lock_attempt {
-                    Ok(mut locked) => {
-                        // Reset failure count on successful lock
-                        consecutive_failures = 0;
-                        
-                        // Try to send ping frame
-                        if let Err(e) = locked.send(Message::Ping(vec![1, 2, 3])).await {
-                            println!("[Socket] ERROR: Error sending WebSocket ping to player {}: {}", player_id_for_ping, e);
-                            consecutive_failures += 1;
-                            
-                            if consecutive_failures >= 3 {
-                                println!("[Socket] Too many consecutive ping failures for player {}, stopping ping service", player_id_for_ping);
-                                break;
-                            }
-                            
-                            continue;
-                        }
-                        
-                        // Try to send application ping
-                        if let Err(e) = locked.send(Message::Text(ping_msg.to_string())).await {
-                            println!("[Socket] ERROR: Error sending application ping to player {}: {}", player_id_for_ping, e);
-                            consecutive_failures += 1;
-                            
-                            if consecutive_failures >= 3 {
-                                println!("[Socket] ERROR: Too many consecutive ping failures for player {}, stopping ping service", player_id_for_ping);
-                                break;
-                            }
-                        }
-                    },
-                    Err(_) => {
-                        // Timeout acquiring lock - count as failure
-                        consecutive_failures += 1;
-                        println!("[Socket] Timeout acquiring lock for ping to player {}", player_id_for_ping);
-                        
-                        if consecutive_failures >= 3 {
-                            println!("[Socket] Too many consecutive ping failures for player {}, stopping ping service", player_id_for_ping);
-                            break;
-                        }
-                    }
-                }
+        let mut bcast = self.tx.subscribe();
+        let mut tx_clone = tx.clone();
+        let forward = tokio::spawn(async move {
+            while let Ok(msg) = bcast.recv().await {
+                if tx_clone.send(msg).await.is_err() { break; }
             }
         });
 
-        // --- 3️⃣ read loop: handle verbs from this client -------------------
-        while let Some(result) = stream.next().await {
-            match result {
-                Ok(Message::Text(text)) => {
-                    // First try to parse the JSON
-                    match serde_json::from_str::<serde_json::Value>(&text) {
-                        Ok(json) => {
-                            // Process the verb only if game has started
-                            if *self.game_started.lock() {
-                                // Handle the json command
-                                if json["verb"] == "place" {
-                                    println!("[Socket] Received place command from player {}: {}", player_id, text);
-                                    let diff = engine::apply_verb(
-                                        &self.bundle,
-                                        &mut self.state.lock(),
-                                        &json,
-                                    );
-    
-                                    let tick = {
-                                        let mut t = self.tick.lock();
-                                        *t += 1;
-                                        *t
-                                    };
-
-                                    let mut patch_ops = Vec::new();
-                                    if let Some(arr) = diff.as_array() {
-                                        for op in arr {
-                                            if let Some(path) = op.get("path").and_then(|p| p.as_str()) {
-                                                let mut op_obj = op.clone();
-                                                op_obj["path"] = serde_json::Value::String(format!("/state{}", path));
-                                                patch_ops.push(op_obj);
-                                            } else {
-                                                patch_ops.push(op.clone());
-                                            }
-                                        }
-                                    }
-
-                                    let current_state = {
-                                        let guard = self.state.lock();
-                                        guard.clone()
-                                    };
-                                    let possible = Lobby::possible_verbs(&current_state);
-                                    for (pid, verbs) in possible {
-                                        patch_ops.push(serde_json::json!({
-                                            "op": "replace",
-                                            "path": format!("/meta/possibleVerbs/{}", pid),
-                                            "value": verbs
-                                        }));
-                                    }
-
-                                    let frame = serde_json::json!({
-                                        "type": "diff",
-                                        "tick": tick,
-                                        "patch": patch_ops
-                                    });
-                                    if let Err(e) = self.tx.send(Message::Text(frame.to_string())) {
-                                        println!("[Socket] ERROR: Error broadcasting event: {}", e);
-                                    }
-                                } else if json["verb"].is_string() {
-                                    println!("[Socket] ERROR: Received unsupported verb '{}' from player {}", json["verb"], player_id);
-                                } 
-                            } else {
-                                println!("[Socket] ERROR: Received command from player {} but game hasn't started yet", player_id);
-                            }
-                        },
-                        Err(e) => {
-                            // Handle non-JSON text messages safely
-                            if text.contains("\"type\":\"pong\"") {
-                                // This is a pong response, just ignore silently
-                            } else {
-                                println!("[Socket] ERROR: Received invalid JSON from player {}: {}", player_id, e);
+        while let Some(Ok(message)) = rx.next().await {
+            if let Message::Text(text) = message {
+                if let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) {
+                    if json["action"] == "join" {
+                        if self.add_player(player_id.clone()) { self.broadcast_lobby_list(); }
+                    } else if json["action"] == "leave" {
+                        if self.remove_player(&player_id) { self.broadcast_lobby_list(); }
+                    } else if json["action"] == "start_game" {
+                        if !self.is_started() && self.players() >= 2 { self.start_game(); }
+                    } else if json["verb"] == "place" && self.is_started() {
+                        let diff = engine::apply_verb(&self.bundle, &mut self.state.lock(), &json);
+                        let tick = { let mut t = self.tick.lock(); *t += 1; *t };
+                        let mut patch_ops = Vec::new();
+                        if let Some(arr) = diff.as_array() {
+                            for op in arr {
+                                if let Some(path) = op.get("path").and_then(|p| p.as_str()) {
+                                    let mut op_obj = op.clone();
+                                    op_obj["path"] = serde_json::Value::String(format!("/state{}", path));
+                                    patch_ops.push(op_obj);
+                                } else {
+                                    patch_ops.push(op.clone());
+                                }
                             }
                         }
-                    }
-                },
-                Ok(Message::Ping(bytes)) => {
-                    match sink.lock().await.send(Message::Pong(bytes)).await {
-                        Ok(_) => {},
-                        Err(e) => {
-                            println!("[Socket] ERROR: Error sending pong: {}", e);
-                            // Don't break here - continue trying to read messages
+                        let current_state = { let g = self.state.lock(); g.clone() };
+                        let possible = Lobby::possible_verbs(&current_state);
+                        for (pid, verbs) in possible {
+                            patch_ops.push(serde_json::json!({"op":"replace","path":format!("/meta/possibleVerbs/{}",pid),"value":verbs}));
                         }
+                        let frame = serde_json::json!({"type":"diff","tick":tick,"patch":patch_ops});
+                        self.history.lock().push(frame.clone());
+                        let _ = self.tx.send(Message::Text(frame.to_string()));
                     }
-                },
-                Ok(Message::Pong(_)) => {
-                    // Received a pong, client is still alive
-                    // Update last ping time if we want to track client aliveness
-                },
-                Ok(Message::Close(frame)) => {
-                    println!("[Socket] WebSocket closed by client: {:?}", frame);
-                    break;
-                },
-                Ok(Message::Binary(_)) => {
-                    println!("[Socket] ERROR: Received binary message, which is not supported");
-                },
-                Err(e) => {
-                    // Check if it's a normal disconnection or a real error
-                    if e.to_string().contains("connection reset") || 
-                       e.to_string().contains("broken pipe") ||
-                       e.to_string().contains("closed") {
-                        // Normal disconnection
-                        println!("[Socket] WebSocket disconnected normally: {}", e);
-                    } else {
-                        // Actual error
-                        println!("[Socket] ERROR: WebSocket error: {}", e);
-                    }
-                    break;
                 }
             }
         }
 
-        // --- disconnect -----------------------------------------------------
-        println!("[Socket] WebSocket connection for player {} disconnected", player_id);
-        forward_handle.abort();
-        ping_handle.abort();
-        
-        // For a clean shutdown, just log that we're disconnecting
-        // Don't attempt to send close frames manually - this often causes errors
-        // WebSockets will be cleaned up automatically
-        println!("[Socket] Connection cleanup complete for player {}", player_id);
+        forward.abort();
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -17,7 +17,7 @@ mod engine;
 mod lobby;
 
 use bundle::BundleMap;
-use crate::lobby::{LobbyMap, new_lobby};
+use crate::lobby::{LobbyMap, new_lobby, current_lobbies_json};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -61,7 +61,7 @@ async fn main() -> anyhow::Result<()> {
             move |ws| lobbies_ws_handler(ws, lobby_updates_for_ws.clone(), lobbies_for_ws_list.clone())
         ))
         .route("/lobbies/:id/ws", get(
-            move |path, ws, query| ws_handler(path, ws, query, lobbies_for_ws.clone())
+            move |path, ws, query| ws_handler(path, ws, query, lobbies_for_ws.clone(), lobby_updates_for_ws.clone())
         ))
         // Apply the CORS middleware
         .layer(cors);
@@ -94,7 +94,7 @@ async fn create_lobby(
     let id = Uuid::new_v4().to_string();
     println!("[HTTP] Creating new lobby: {} for game: {}", id, game_id);
     
-    lobbies.insert(id.clone(), new_lobby(id.clone(), bundle));
+    lobbies.insert(id.clone(), new_lobby(id.clone(), bundle, lobbies.clone(), lobby_updates.clone()));
 
     // broadcast updated lobby list
     let list = current_lobbies_json(&lobbies);
@@ -138,22 +138,6 @@ async fn list_games(
     Json(game_list)
 }
 
-fn current_lobbies_json(lobbies: &LobbyMap) -> serde_json::Value {
-    let list = lobbies
-        .iter()
-        .map(|l| {
-            let lobby = l.value();
-            serde_json::json!({
-                "id": l.key(),
-                "game_id": lobby.bundle.game_id,
-                "name": format!("{} - Lobby {}", lobby.bundle.game_id, &l.key()[0..6]),
-                "players": lobby.player_list(),
-                "started": lobby.is_started()
-            })
-        })
-        .collect::<Vec<_>>();
-    serde_json::Value::Array(list)
-}
 
 async fn lobbies_ws_handler(
     ws: WebSocketUpgrade,
@@ -186,14 +170,16 @@ async fn lobbies_ws_handler(
 async fn ws_handler(
     Path(id): Path<String>,
     ws: WebSocketUpgrade,
-    // Access query parameters to get player_id
     axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
     lobbies: Arc<LobbyMap>,
+    lobby_updates: broadcast::Sender<Message>,
 ) -> impl IntoResponse {
     // Extract player_id from query params, default to a random ID if missing
     let player_id = params.get("player_id").cloned().unwrap_or_else(|| {
         format!("guest_{}", uuid::Uuid::new_v4().to_string().split('-').next().unwrap())
     });
+    let join = params.get("join").map(|v| v != "0" && v != "false").unwrap_or(true);
+    let since = params.get("since").and_then(|s| s.parse::<u64>().ok()).unwrap_or(0);
     
     println!("[Socket] Connection request from player {} for lobby {}", player_id, id);
     
@@ -217,24 +203,8 @@ async fn ws_handler(
         lobby.is_started()
     );
     
-    // Add player to the lobby
-    let added = lobby.add_player(player_id.clone());
-    
-    println!("[Socket] Player {} attempted to join lobby {}. Added: {}", player_id, id, added);
-    
-    if !added {
-        // Player couldn't be added (lobby full)
-        println!("[Socket] ERROR: Could not add player {} to lobby {}: lobby is full", player_id, id);
-        return ws.on_upgrade(|mut sock| async move {
-            let _ = sock.send(Message::Text(serde_json::json!({
-                "type": "error",
-                "message": "Could not join lobby - it may be full"
-            }).to_string())).await;
-        });
-    }
-    
     ws.on_upgrade(move |sock| async move {
         println!("[Socket] WebSocket connections successful for player {} in lobby {}", player_id, id);
-        lobby.accept_client(sock).await;
+        lobby.accept_client(sock, player_id, join, since).await;
     })
 }


### PR DESCRIPTION
## Summary
- remember username across refresh with localStorage
- show lobby player names and status and open lobby instead of immediately joining
- allow joining/leaving the lobby and starting the game from LobbyView
- send lobby updates and diff history from the server
- revise server lobby routes to support new behaviour

## Testing
- `npx tsc -p clients/react/tsconfig.app.json --noEmit` *(fails: Cannot find module 'react')*