### PR TITLE
Show game manifest on lobby view

### DIFF
--- a/clients/react/src/api/games.ts
+++ b/clients/react/src/api/games.ts
@@ -8,3 +8,21 @@ export async function getGames(): Promise<Game[]> {
   if (!res.ok) throw new Error("Failed to fetch list of games");
   return res.json();
 }
+
+export type GameManifest = {
+  gameId: string;
+  version: string;
+  specVersion: string;
+  metadata: {
+    name: string;
+    author: string;
+    players: { min: number; max: number };
+    description: string;
+  };
+};
+
+export async function getGameManifest(gameId: string): Promise<GameManifest> {
+  const res = await fetch(`http://localhost:8000/games/${gameId}`);
+  if (!res.ok) throw new Error("Failed to fetch game manifest");
+  return res.json();
+}

--- a/clients/react/src/api/lobbies.ts
+++ b/clients/react/src/api/lobbies.ts
@@ -21,3 +21,9 @@ export async function createLobby(game_id: string): Promise<Lobby> {
   if (!res.ok) throw new Error("Failed to create lobby");
   return res.json();
 }
+
+export async function getLobby(id: string): Promise<Lobby & { manifest: any }> {
+  const res = await fetch(`http://localhost:8000/lobbies/${id}`);
+  if (!res.ok) throw new Error("Failed to fetch lobby");
+  return res.json();
+}

--- a/clients/react/src/components/LobbyView.tsx
+++ b/clients/react/src/components/LobbyView.tsx
@@ -1,8 +1,11 @@
 import { usePlayer } from "../context/PlayerContext";
 import { useLobbyWebSocket } from "../ws/useLobbyWebSocket";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Board from "./Board";
 import TurnIndicator from "./TurnIndicator";
+import { getLobby } from "../api/lobbies";
+
+import type { GameManifest } from "../api/games";
 
 type Props = {
   lobbyId: string;
@@ -11,29 +14,70 @@ type Props = {
 
 export default function LobbyView({ lobbyId, onLeave }: Props) {
   const { player } = usePlayer();
-  const [input, setInput] = useState("");
-  const { messages, sendMessage, lobbyState, joinLobby, leaveLobby, startGame } = useLobbyWebSocket(lobbyId, player!.username, false);
+  const { lobbyState, joinLobby, leaveLobby, startGame } = useLobbyWebSocket(lobbyId, player!.username, false);
   const joined = lobbyState.you && lobbyState.you !== "spectator";
+  const [lobbyInfo, setLobbyInfo] = useState<{
+    id: string;
+    game_id: string;
+    players: string[];
+    started: boolean;
+    manifest: GameManifest;
+  } | null>(null);
+
+  useEffect(() => {
+    getLobby(lobbyId).then(setLobbyInfo).catch(() => {});
+  }, [lobbyId]);
+
+  const canStart = lobbyInfo &&
+    lobbyInfo.players.length >= lobbyInfo.manifest.metadata.players.min &&
+    lobbyInfo.players.length <= lobbyInfo.manifest.metadata.players.max;
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl space-y-6">
-      <div className="card">
-        <div className="flex justify-between items-center mb-6">
-          <h2 className="text-2xl font-bold">Lobby {lobbyId}</h2>
-          <button onClick={onLeave} className="btn btn-secondary">
-            Back to Lobbies
-          </button>
+      <div className="flex justify-between mb-4">
+        <h2 className="text-2xl font-bold">Lobby {lobbyId}</h2>
+        <button onClick={onLeave} className="btn btn-secondary">Back to Lobbies</button>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="card space-y-4">
+          <h3 className="text-xl font-semibold">Lobby Info</h3>
+          <p><strong>ID:</strong> {lobbyId}</p>
+          <p><strong>Players:</strong> {lobbyInfo ? lobbyInfo.players.join(", ") || "None" : "Loading..."}</p>
+          {joined ? (
+            <button onClick={leaveLobby} className="btn btn-secondary">Leave Lobby</button>
+          ) : (
+            <button onClick={joinLobby} className="btn btn-primary">Join Lobby</button>
+          )}
         </div>
 
-        <div className="space-y-4">
-          {joined ? (
-            <button onClick={leaveLobby} className="btn btn-secondary">Leave Game</button>
+        <div className="card space-y-4">
+          <h3 className="text-xl font-semibold">Game Info</h3>
+          {lobbyInfo ? (
+            <>
+              <p><strong>Name:</strong> {lobbyInfo.manifest.metadata.name}</p>
+              <p><strong>Author:</strong> {lobbyInfo.manifest.metadata.author}</p>
+              <p><strong>Description:</strong> {lobbyInfo.manifest.metadata.description}</p>
+              <p><strong>Version:</strong> {lobbyInfo.manifest.version}</p>
+              <p><strong>Spec Version:</strong> {lobbyInfo.manifest.specVersion}</p>
+              <p><strong>Players:</strong> {lobbyInfo.manifest.metadata.players.min} - {lobbyInfo.manifest.metadata.players.max}</p>
+              <button onClick={startGame} disabled={!canStart} className="btn btn-primary">
+                Start Game
+              </button>
+              {!canStart && (
+                <p className="text-sm text-gray-400">
+                  Need {lobbyInfo.manifest.metadata.players.min} to {lobbyInfo.manifest.metadata.players.max} players to start.
+                </p>
+              )}
+            </>
           ) : (
-            <button onClick={joinLobby} className="btn btn-primary">Join Game</button>
+            <p>Loading...</p>
           )}
-          {joined && !lobbyState.started && lobbyState.state && (
-            <button onClick={startGame} className="btn btn-primary ml-2">Start Game</button>
-          )}
+        </div>
+      </div>
+
+      {lobbyState.started && (
+        <div className="card space-y-4">
           <TurnIndicator
             you={lobbyState.you}
             turn={lobbyState.state?.turn}
@@ -41,58 +85,7 @@ export default function LobbyView({ lobbyId, onLeave }: Props) {
           />
           <Board board={lobbyState.state?.zones?.board ?? []} />
         </div>
-      </div>
-
-      <div className="card space-y-4">
-        <h3 className="text-xl font-semibold">Current Game State</h3>
-        <pre className="bg-gray-700 p-4 rounded-lg overflow-auto text-sm">
-          {JSON.stringify(lobbyState, null, 2)}
-        </pre>
-      </div>
-
-      <div className="card">
-        <form
-          onSubmit={e => {
-            e.preventDefault();
-            if (input.trim()) {
-              sendMessage(input);
-              setInput("");
-            }
-          }}
-          className="space-y-4"
-        >
-          <div className="flex gap-3">
-            <input
-              value={input}
-              onChange={e => setInput(e.target.value)}
-              className="input flex-1"
-              placeholder="Type a JSON message to send"
-            />
-            <button type="submit" className="btn btn-primary">
-              Send
-            </button>
-          </div>
-        </form>
-
-        <div className="grid grid-cols-2 gap-6 mt-6">
-          <div>
-            <h3 className="text-lg font-semibold mb-3">Received</h3>
-            <ul className="bg-gray-700 rounded-lg p-4 min-h-[100px] space-y-2 text-sm">
-              {messages.filter(m => m.direction === "received").map((m, i) => (
-                <li key={i} className="break-all">{m.content}</li>
-              ))}
-            </ul>
-          </div>
-          <div>
-            <h3 className="text-lg font-semibold mb-3">Sent</h3>
-            <ul className="bg-gray-700 rounded-lg p-4 min-h-[100px] space-y-2 text-sm">
-              {messages.filter(m => m.direction === "sent").map((m, i) => (
-                <li key={i} className="break-all">{m.content}</li>
-              ))}
-            </ul>
-          </div>
-        </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/server/src/bundle.rs
+++ b/server/src/bundle.rs
@@ -1,41 +1,74 @@
-// No imports needed here - we're defining Bundle directly
-// Remove the circular import
-// use crate::bundle::Bundle;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, fs};
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct PlayersRange {
+    pub min: u32,
+    pub max: u32,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ManifestMetadata {
+    pub name: String,
+    pub author: String,
+    pub players: PlayersRange,
+    pub description: String,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Manifest {
+    #[serde(rename = "gameId")]
+    pub game_id: String,
+    pub version: String,
+    #[serde(rename = "specVersion")]
+    pub spec_version: String,
+    pub metadata: ManifestMetadata,
+}
 
 #[derive(Clone)]
 pub struct Bundle {
     pub game_id: String,
-    // Add other fields as needed
+    pub manifest: Manifest,
 }
 
 #[derive(Clone)]
 pub struct BundleMap {
-    // In a real implementation, this would be a map of game IDs to bundles
-    // For simplicity, we'll use a hardcoded approach for this example
+    bundles: HashMap<String, Bundle>,
 }
 
 impl BundleMap {
-    pub fn load_dir(_path: &str) -> anyhow::Result<Self> {
-        // Implementation
-        Ok(Self { /* initialize fields */ })
-    }
-    
-    pub fn get_latest(&self, game_id: &str) -> Option<Bundle> {
-        // For this example, we'll just return a bundle with the requested game_id
-        // In a real implementation, you'd lookup the game in a map
-        
-        // Only allow tic-tac-toe for now
-        if game_id == "tic-tac-toe" {
-            return Some(Bundle { 
-                game_id: game_id.to_string(),
-            });
+    pub fn load_dir(path: &str) -> anyhow::Result<Self> {
+        let mut bundles = HashMap::new();
+        for entry in fs::read_dir(path)? {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let game_id = entry.file_name().to_string_lossy().to_string();
+            // find latest version directory
+            let mut versions: Vec<String> = fs::read_dir(entry.path())?
+                .filter_map(|e| e.ok())
+                .filter(|e| e.file_type().ok().map(|f| f.is_dir()).unwrap_or(false))
+                .map(|e| e.file_name().to_string_lossy().to_string())
+                .collect();
+            versions.sort();
+            if let Some(ver) = versions.last() {
+                let manifest_path = entry.path().join(ver).join("manifest.yaml");
+                if manifest_path.exists() {
+                    let contents = fs::read_to_string(&manifest_path)?;
+                    let manifest: Manifest = serde_yaml::from_str(&contents)?;
+                    bundles.insert(game_id.clone(), Bundle { game_id: game_id.clone(), manifest });
+                }
+            }
         }
-        
-        None
+        Ok(Self { bundles })
+    }
+
+    pub fn get_latest(&self, game_id: &str) -> Option<Bundle> {
+        self.bundles.get(game_id).cloned()
     }
 
     pub fn list_games(&self) -> Vec<String> {
-        // For simplicity, just return tic-tac-toe
-        vec!["tic-tac-toe".to_string()]
+        self.bundles.keys().cloned().collect()
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -21,7 +21,9 @@ use crate::lobby::{LobbyMap, new_lobby, current_lobbies_json};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let bundles = BundleMap::load_dir("./games")?;
+    // load games relative to workspace root so running from `server/` works
+    let games_dir = format!("{}/../games", env!("CARGO_MANIFEST_DIR"));
+    let bundles = BundleMap::load_dir(&games_dir)?;
     
     // Wrap the DashMap in an Arc to ensure proper sharing between requests
     let lobbies = Arc::new(LobbyMap::default());
@@ -30,6 +32,7 @@ async fn main() -> anyhow::Result<()> {
     // Clone for each route handler
     let bundles_for_games = bundles.clone();
     let bundles_for_lobbies = bundles.clone();
+    let bundles_for_manifest = bundles.clone();
     let lobbies_for_lobbies_route = lobbies.clone();
     let lobbies_for_ws = lobbies.clone();
     let lobbies_for_create = lobbies.clone();
@@ -47,6 +50,7 @@ async fn main() -> anyhow::Result<()> {
 
     let app = Router::new()
         .route("/games", get(move || list_games(bundles_for_games.clone())))
+        .route("/games/:id", get(move |path| get_game(path, bundles_for_manifest.clone())))
         .route("/lobbies", post(
             move |req| create_lobby(
                 req,
@@ -57,6 +61,7 @@ async fn main() -> anyhow::Result<()> {
         ).get(
             move || list_lobbies(lobbies_for_lobbies_route.clone())
         ))
+        .route("/lobbies/:id", get(move |path| get_lobby(path, lobbies.clone())))
         .route("/lobbies/ws", get(
             move |ws| lobbies_ws_handler(ws, lobby_updates_for_ws_list.clone(), lobbies_for_ws_list.clone())
         ))
@@ -136,6 +141,35 @@ async fn list_games(
     }).collect::<Vec<_>>();
     
     Json(game_list)
+}
+
+async fn get_game(
+    Path(id): Path<String>,
+    bundles: BundleMap,
+) -> impl IntoResponse {
+    if let Some(bundle) = bundles.get_latest(&id) {
+        Json(serde_json::to_value(&bundle.manifest).unwrap())
+    } else {
+        Json(serde_json::json!({ "error": "Unknown game" }))
+    }
+}
+
+async fn get_lobby(
+    Path(id): Path<String>,
+    lobbies: Arc<LobbyMap>,
+) -> impl IntoResponse {
+    if let Some(lobby_ref) = lobbies.get(&id) {
+        let lobby = lobby_ref.value();
+        Json(serde_json::json!({
+            "id": lobby.id,
+            "game_id": lobby.bundle.game_id,
+            "players": lobby.player_list(),
+            "started": lobby.is_started(),
+            "manifest": lobby.bundle.manifest
+        }))
+    } else {
+        Json(serde_json::json!({ "error": "Lobby not found" }))
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- parse manifest.yaml for each game when the server starts
- expose `/games/:id` and `/lobbies/:id` endpoints with manifest info
- fetch lobby details in the React client and display lobby/game info
- display Start Game button conditionally
- fix server path to load games directory correctly

## Testing
- `npx tsc --noEmit`
- `cargo check` *(fails: could not connect to crates.io)*