### PR TITLE
Fix websocket reconnection loop

### DIFF
--- a/clients/react/src/ws/useLobbyWebSocket.ts
+++ b/clients/react/src/ws/useLobbyWebSocket.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { applyPatch } from "fast-json-patch";
 import { useWebSocket, type WSMessage } from "./useWebSocket";
 
@@ -15,8 +15,12 @@ export function useLobbyWebSocket(
   autoJoin: boolean
 ) {
   const [lobbyState, setLobbyState] = useState<LobbyState>({});
-  const [lastTick, setLastTick] = useState(() => Number(localStorage.getItem(`lobby_${lobbyId}_lastTick`) || "0"));
-  const url = `ws://localhost:8000/lobbies/${lobbyId}/ws?player_id=${encodeURIComponent(playerId)}&join=${autoJoin ? 1 : 0}&since=${lastTick}`;
+  const lastTickRef = useRef<number>(
+    Number(localStorage.getItem(`lobby_${lobbyId}_lastTick`) || "0")
+  );
+  const url = `ws://localhost:8000/lobbies/${lobbyId}/ws?player_id=${encodeURIComponent(
+    playerId
+  )}&join=${autoJoin ? 1 : 0}&since=${lastTickRef.current}`;
 
   const { messages, sendMessage } = useWebSocket(url, dataStr => {
     let data: any;
@@ -33,22 +37,25 @@ export function useLobbyWebSocket(
         state: data.state,
         started: data.started,
       });
-      if (typeof data.tick === "number") setLastTick(data.tick);
+      if (typeof data.tick === "number") lastTickRef.current = data.tick;
     } else if (data.type === "diff" && Array.isArray(data.patch)) {
       setLobbyState(prev => {
         const full = { meta: prev.meta, state: prev.state };
         const patched = applyPatch({ ...full }, data.patch, true, false).newDocument as LobbyState;
         return { ...patched, you: prev.you, started: prev.started };
       });
-      if (typeof data.tick === "number") setLastTick(data.tick);
+      if (typeof data.tick === "number") lastTickRef.current = data.tick;
     }
   });
 
   useEffect(() => {
     return () => {
-      localStorage.setItem(`lobby_${lobbyId}_lastTick`, String(lastTick));
+      localStorage.setItem(
+        `lobby_${lobbyId}_lastTick`,
+        String(lastTickRef.current)
+      );
     };
-  }, [lastTick, lobbyId]);
+  }, [lobbyId]);
 
   const joinLobby = () => sendMessage(JSON.stringify({ action: "join" }));
   const leaveLobby = () => sendMessage(JSON.stringify({ action: "leave" }));

--- a/clients/react/src/ws/useWebSocket.ts
+++ b/clients/react/src/ws/useWebSocket.ts
@@ -12,6 +12,8 @@ export function useWebSocket(
   const [messages, setMessages] = useState<WSMessage[]>([]);
   const wsRef = useRef<WebSocket | null>(null);
   const onMessageRef = useRef<(data: string) => void>(() => {});
+  const reconnectTimer = useRef<number | null>(null);
+  const pendingMessages = useRef<string[]>([]);
 
   useEffect(() => {
     onMessageRef.current = onMessage;
@@ -21,21 +23,43 @@ export function useWebSocket(
     if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
       wsRef.current.send(content);
       setMessages(msgs => [{ direction: "sent", content }, ...msgs]);
+    } else {
+      pendingMessages.current.push(content);
     }
   }, []);
 
   useEffect(() => {
-    setMessages([]);
-    const ws = new WebSocket(url);
-    wsRef.current = ws;
+    let active = true;
 
-    ws.onmessage = (event) => {
-      setMessages(msgs => [{ direction: "received", content: event.data }, ...msgs]);
-      onMessageRef.current(event.data);
-    };
+    function connect() {
+      if (!active) return;
+      const ws = new WebSocket(url);
+      wsRef.current = ws;
+      ws.onopen = () => {
+        pendingMessages.current.forEach(m => ws.send(m));
+        pendingMessages.current = [];
+      };
+      ws.onmessage = (event) => {
+        setMessages(msgs => [{ direction: "received", content: event.data }, ...msgs]);
+        onMessageRef.current(event.data);
+      };
+      ws.onclose = () => {
+        if (active) {
+          reconnectTimer.current = window.setTimeout(connect, 1000);
+        }
+      };
+      ws.onerror = () => {
+        ws.close();
+      };
+    }
+
+    setMessages([]);
+    connect();
 
     return () => {
-      ws.close();
+      active = false;
+      if (reconnectTimer.current) clearTimeout(reconnectTimer.current);
+      wsRef.current?.close();
     };
   }, [url]);
 


### PR DESCRIPTION
## Summary
- avoid reopening lobby websocket after each message
- retry websocket connections when they close or fail

## Testing
- `cargo test --quiet --manifest-path server/Cargo.toml` *(fails: Could not connect to server)*