### PR TITLE
Fix websocket reconnection loop

### DIFF
--- a/clients/react/src/components/LobbyView.tsx
+++ b/clients/react/src/components/LobbyView.tsx
@@ -1,5 +1,6 @@
 import { usePlayer } from "../context/PlayerContext";
 import { useLobbyWebSocket } from "../ws/useLobbyWebSocket";
+import { useLobbiesWebSocket } from "../ws/useLobbiesWebSocket";
 import { useState, useEffect } from "react";
 import Board from "./Board";
 import TurnIndicator from "./TurnIndicator";
@@ -24,11 +25,19 @@ export default function LobbyView({ lobbyId, onLeave }: Props) {
     manifest: GameManifest;
   } | null>(null);
 
+  useLobbiesWebSocket((lobbies) => {
+    const lobby = lobbies.find((l) => l.id === lobbyId);
+    if (lobby) {
+      setLobbyInfo((info) => (info ? { ...info, ...lobby } : info));
+    }
+  });
+
   useEffect(() => {
     getLobby(lobbyId).then(setLobbyInfo).catch(() => {});
   }, [lobbyId]);
 
-  const canStart = lobbyInfo &&
+  const canStart =
+    lobbyInfo &&
     lobbyInfo.players.length >= lobbyInfo.manifest.metadata.players.min &&
     lobbyInfo.players.length <= lobbyInfo.manifest.metadata.players.max;
 

--- a/clients/react/src/ws/useLobbyWebSocket.ts
+++ b/clients/react/src/ws/useLobbyWebSocket.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { applyPatch } from "fast-json-patch";
 import { useWebSocket, type WSMessage } from "./useWebSocket";
 
@@ -15,8 +15,16 @@ export function useLobbyWebSocket(
   autoJoin: boolean
 ) {
   const [lobbyState, setLobbyState] = useState<LobbyState>({});
-  const [lastTick, setLastTick] = useState(() => Number(localStorage.getItem(`lobby_${lobbyId}_lastTick`) || "0"));
-  const url = `ws://localhost:8000/lobbies/${lobbyId}/ws?player_id=${encodeURIComponent(playerId)}&join=${autoJoin ? 1 : 0}&since=${lastTick}`;
+  const lastTickRef = useRef<number>(
+    Number(localStorage.getItem(`lobby_${lobbyId}_lastTick`) || "0")
+  );
+  const url = useMemo(
+    () =>
+      `ws://localhost:8000/lobbies/${lobbyId}/ws?player_id=${encodeURIComponent(
+        playerId
+      )}&join=${autoJoin ? 1 : 0}&since=${lastTickRef.current}`,
+    [lobbyId, playerId, autoJoin]
+  );
 
   const { messages, sendMessage } = useWebSocket(url, dataStr => {
     let data: any;
@@ -33,22 +41,25 @@ export function useLobbyWebSocket(
         state: data.state,
         started: data.started,
       });
-      if (typeof data.tick === "number") setLastTick(data.tick);
+      if (typeof data.tick === "number") lastTickRef.current = data.tick;
     } else if (data.type === "diff" && Array.isArray(data.patch)) {
       setLobbyState(prev => {
         const full = { meta: prev.meta, state: prev.state };
         const patched = applyPatch({ ...full }, data.patch, true, false).newDocument as LobbyState;
         return { ...patched, you: prev.you, started: prev.started };
       });
-      if (typeof data.tick === "number") setLastTick(data.tick);
+      if (typeof data.tick === "number") lastTickRef.current = data.tick;
     }
   });
 
   useEffect(() => {
     return () => {
-      localStorage.setItem(`lobby_${lobbyId}_lastTick`, String(lastTick));
+      localStorage.setItem(
+        `lobby_${lobbyId}_lastTick`,
+        String(lastTickRef.current)
+      );
     };
-  }, [lastTick, lobbyId]);
+  }, [lobbyId]);
 
   const joinLobby = () => sendMessage(JSON.stringify({ action: "join" }));
   const leaveLobby = () => sendMessage(JSON.stringify({ action: "leave" }));

--- a/clients/react/src/ws/useWebSocket.ts
+++ b/clients/react/src/ws/useWebSocket.ts
@@ -11,6 +11,7 @@ export function useWebSocket(
 ) {
   const [messages, setMessages] = useState<WSMessage[]>([]);
   const wsRef = useRef<WebSocket | null>(null);
+  const pendingRef = useRef<string[]>([]);
   const onMessageRef = useRef<(data: string) => void>(() => {});
 
   useEffect(() => {
@@ -20,22 +21,52 @@ export function useWebSocket(
   const sendMessage = useCallback((content: string) => {
     if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
       wsRef.current.send(content);
-      setMessages(msgs => [{ direction: "sent", content }, ...msgs]);
+    } else {
+      pendingRef.current.push(content);
     }
+    setMessages(msgs => [{ direction: "sent", content }, ...msgs]);
   }, []);
 
   useEffect(() => {
     setMessages([]);
-    const ws = new WebSocket(url);
-    wsRef.current = ws;
+    let ws: WebSocket | null = null;
+    let reconnectTimer: number;
+    let shouldReconnect = true;
 
-    ws.onmessage = (event) => {
-      setMessages(msgs => [{ direction: "received", content: event.data }, ...msgs]);
-      onMessageRef.current(event.data);
+    const connect = () => {
+      ws = new WebSocket(url);
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        pendingRef.current.forEach((msg) => ws!.send(msg));
+        pendingRef.current = [];
+      };
+
+      ws.onmessage = (event) => {
+        setMessages((msgs) => [
+          { direction: "received", content: event.data },
+          ...msgs,
+        ]);
+        onMessageRef.current(event.data);
+      };
+
+      ws.onclose = () => {
+        if (shouldReconnect) {
+          reconnectTimer = window.setTimeout(connect, 1000);
+        }
+      };
+
+      ws.onerror = () => {
+        ws?.close();
+      };
     };
 
+    connect();
+
     return () => {
-      ws.close();
+      shouldReconnect = false;
+      clearTimeout(reconnectTimer);
+      ws?.close();
     };
   }, [url]);
 


### PR DESCRIPTION
## Summary
- keep lobby websocket open by memoizing URL
- reconnect and queue unsent messages in base websocket hook
- update lobby view with player counts from lobbies feed

## Testing
- `cargo test --quiet --manifest-path server/Cargo.toml` *(fails: Could not connect to server)*