### PR TITLE
Fix lobby start updates

### DIFF
--- a/clients/react/src/components/LobbyView.tsx
+++ b/clients/react/src/components/LobbyView.tsx
@@ -1,11 +1,12 @@
-import { usePlayer } from "../context/PlayerContext";
-import { useLobbyWebSocket } from "../ws/useLobbyWebSocket";
-import { useState, useEffect } from "react";
-import Board from "./Board";
-import TurnIndicator from "./TurnIndicator";
-import { getLobby } from "../api/lobbies";
+import { usePlayer } from '../context/PlayerContext';
+import { useLobbyWebSocket } from '../ws/useLobbyWebSocket';
+import { useLobbiesWebSocket } from '../ws/useLobbiesWebSocket';
+import { useState, useEffect } from 'react';
+import Board from './Board';
+import TurnIndicator from './TurnIndicator';
+import { getLobby } from '../api/lobbies';
 
-import type { GameManifest } from "../api/games";
+import type { GameManifest } from '../api/games';
 
 type Props = {
   lobbyId: string;
@@ -14,8 +15,12 @@ type Props = {
 
 export default function LobbyView({ lobbyId, onLeave }: Props) {
   const { player } = usePlayer();
-  const { lobbyState, joinLobby, leaveLobby, startGame } = useLobbyWebSocket(lobbyId, player!.username, false);
-  const joined = lobbyState.you && lobbyState.you !== "spectator";
+  const { lobbyState, joinLobby, leaveLobby, startGame } = useLobbyWebSocket(
+    lobbyId,
+    player!.username,
+    false,
+  );
+  const joined = lobbyState.you && lobbyState.you !== 'spectator';
   const [lobbyInfo, setLobbyInfo] = useState<{
     id: string;
     game_id: string;
@@ -25,10 +30,25 @@ export default function LobbyView({ lobbyId, onLeave }: Props) {
   } | null>(null);
 
   useEffect(() => {
-    getLobby(lobbyId).then(setLobbyInfo).catch(() => {});
+    getLobby(lobbyId)
+      .then(setLobbyInfo)
+      .catch(() => {});
   }, [lobbyId]);
 
-  const canStart = lobbyInfo &&
+  useLobbiesWebSocket((lobbies) => {
+    setLobbyInfo((prev) => {
+      if (!prev) return prev;
+      const updated = lobbies.find((l) => l.id === lobbyId);
+      if (updated) {
+        return { ...prev, players: updated.players, started: updated.started };
+      }
+      return prev;
+    });
+  });
+
+  const canStart =
+    lobbyInfo &&
+    !lobbyInfo.started &&
     lobbyInfo.players.length >= lobbyInfo.manifest.metadata.players.min &&
     lobbyInfo.players.length <= lobbyInfo.manifest.metadata.players.max;
 
@@ -36,18 +56,29 @@ export default function LobbyView({ lobbyId, onLeave }: Props) {
     <div className="container mx-auto px-4 py-8 max-w-4xl space-y-6">
       <div className="flex justify-between mb-4">
         <h2 className="text-2xl font-bold">Lobby {lobbyId}</h2>
-        <button onClick={onLeave} className="btn btn-secondary">Back to Lobbies</button>
+        <button onClick={onLeave} className="btn btn-secondary">
+          Back to Lobbies
+        </button>
       </div>
 
       <div className="grid gap-6 md:grid-cols-2">
         <div className="card space-y-4">
           <h3 className="text-xl font-semibold">Lobby Info</h3>
-          <p><strong>ID:</strong> {lobbyId}</p>
-          <p><strong>Players:</strong> {lobbyInfo ? lobbyInfo.players.join(", ") || "None" : "Loading..."}</p>
+          <p>
+            <strong>ID:</strong> {lobbyId}
+          </p>
+          <p>
+            <strong>Players:</strong>{' '}
+            {lobbyInfo ? lobbyInfo.players.join(', ') || 'None' : 'Loading...'}
+          </p>
           {joined ? (
-            <button onClick={leaveLobby} className="btn btn-secondary">Leave Lobby</button>
+            <button onClick={leaveLobby} className="btn btn-secondary">
+              Leave Lobby
+            </button>
           ) : (
-            <button onClick={joinLobby} className="btn btn-primary">Join Lobby</button>
+            <button onClick={joinLobby} className="btn btn-primary">
+              Join Lobby
+            </button>
           )}
         </div>
 
@@ -55,18 +86,38 @@ export default function LobbyView({ lobbyId, onLeave }: Props) {
           <h3 className="text-xl font-semibold">Game Info</h3>
           {lobbyInfo ? (
             <>
-              <p><strong>Name:</strong> {lobbyInfo.manifest.metadata.name}</p>
-              <p><strong>Author:</strong> {lobbyInfo.manifest.metadata.author}</p>
-              <p><strong>Description:</strong> {lobbyInfo.manifest.metadata.description}</p>
-              <p><strong>Version:</strong> {lobbyInfo.manifest.version}</p>
-              <p><strong>Spec Version:</strong> {lobbyInfo.manifest.specVersion}</p>
-              <p><strong>Players:</strong> {lobbyInfo.manifest.metadata.players.min} - {lobbyInfo.manifest.metadata.players.max}</p>
-              <button onClick={startGame} disabled={!canStart} className="btn btn-primary">
+              <p>
+                <strong>Name:</strong> {lobbyInfo.manifest.metadata.name}
+              </p>
+              <p>
+                <strong>Author:</strong> {lobbyInfo.manifest.metadata.author}
+              </p>
+              <p>
+                <strong>Description:</strong>{' '}
+                {lobbyInfo.manifest.metadata.description}
+              </p>
+              <p>
+                <strong>Version:</strong> {lobbyInfo.manifest.version}
+              </p>
+              <p>
+                <strong>Spec Version:</strong> {lobbyInfo.manifest.specVersion}
+              </p>
+              <p>
+                <strong>Players:</strong>{' '}
+                {lobbyInfo.manifest.metadata.players.min} -{' '}
+                {lobbyInfo.manifest.metadata.players.max}
+              </p>
+              <button
+                onClick={startGame}
+                disabled={!canStart}
+                className="btn btn-primary"
+              >
                 Start Game
               </button>
               {!canStart && (
                 <p className="text-sm text-gray-400">
-                  Need {lobbyInfo.manifest.metadata.players.min} to {lobbyInfo.manifest.metadata.players.max} players to start.
+                  Need {lobbyInfo.manifest.metadata.players.min} to{' '}
+                  {lobbyInfo.manifest.metadata.players.max} players to start.
                 </p>
               )}
             </>

--- a/clients/react/src/ws/useLobbyWebSocket.ts
+++ b/clients/react/src/ws/useLobbyWebSocket.ts
@@ -1,6 +1,6 @@
-import { useState, useEffect } from "react";
-import { applyPatch } from "fast-json-patch";
-import { useWebSocket, type WSMessage } from "./useWebSocket";
+import { useState, useEffect, useRef } from 'react';
+import { applyPatch } from 'fast-json-patch';
+import { useWebSocket, type WSMessage } from './useWebSocket';
 
 export type LobbyState = {
   you?: string;
@@ -12,13 +12,17 @@ export type LobbyState = {
 export function useLobbyWebSocket(
   lobbyId: string,
   playerId: string,
-  autoJoin: boolean
+  autoJoin: boolean,
 ) {
   const [lobbyState, setLobbyState] = useState<LobbyState>({});
-  const [lastTick, setLastTick] = useState(() => Number(localStorage.getItem(`lobby_${lobbyId}_lastTick`) || "0"));
-  const url = `ws://localhost:8000/lobbies/${lobbyId}/ws?player_id=${encodeURIComponent(playerId)}&join=${autoJoin ? 1 : 0}&since=${lastTick}`;
+  const lastTickRef = useRef<number>(
+    Number(localStorage.getItem(`lobby_${lobbyId}_lastTick`) || '0'),
+  );
+  const url = `ws://localhost:8000/lobbies/${lobbyId}/ws?player_id=${encodeURIComponent(
+    playerId,
+  )}&join=${autoJoin ? 1 : 0}&since=${lastTickRef.current}`;
 
-  const { messages, sendMessage } = useWebSocket(url, dataStr => {
+  const { messages, sendMessage } = useWebSocket(url, (dataStr) => {
     let data: any;
     try {
       data = JSON.parse(dataStr);
@@ -26,33 +30,46 @@ export function useLobbyWebSocket(
       return;
     }
 
-    if (data.type === "welcome") {
+    if (data.type === 'welcome') {
       setLobbyState({
         you: data.you,
         meta: data.meta,
         state: data.state,
         started: data.started,
       });
-      if (typeof data.tick === "number") setLastTick(data.tick);
-    } else if (data.type === "diff" && Array.isArray(data.patch)) {
-      setLobbyState(prev => {
+      if (typeof data.tick === 'number') lastTickRef.current = data.tick;
+    } else if (data.type === 'diff' && Array.isArray(data.patch)) {
+      setLobbyState((prev) => {
         const full = { meta: prev.meta, state: prev.state };
-        const patched = applyPatch({ ...full }, data.patch, true, false).newDocument as LobbyState;
+        const patched = applyPatch({ ...full }, data.patch, true, false)
+          .newDocument as LobbyState;
         return { ...patched, you: prev.you, started: prev.started };
       });
-      if (typeof data.tick === "number") setLastTick(data.tick);
+      if (typeof data.tick === 'number') lastTickRef.current = data.tick;
+    } else if (data.type === 'started') {
+      setLobbyState((prev) => ({ ...prev, started: true }));
     }
   });
 
   useEffect(() => {
     return () => {
-      localStorage.setItem(`lobby_${lobbyId}_lastTick`, String(lastTick));
+      localStorage.setItem(
+        `lobby_${lobbyId}_lastTick`,
+        String(lastTickRef.current),
+      );
     };
-  }, [lastTick, lobbyId]);
+  }, [lobbyId]);
 
-  const joinLobby = () => sendMessage(JSON.stringify({ action: "join" }));
-  const leaveLobby = () => sendMessage(JSON.stringify({ action: "leave" }));
-  const startGame = () => sendMessage(JSON.stringify({ action: "start_game" }));
+  const joinLobby = () => sendMessage(JSON.stringify({ action: 'join' }));
+  const leaveLobby = () => sendMessage(JSON.stringify({ action: 'leave' }));
+  const startGame = () => sendMessage(JSON.stringify({ action: 'start_game' }));
 
-  return { messages, sendMessage, lobbyState, joinLobby, leaveLobby, startGame };
+  return {
+    messages,
+    sendMessage,
+    lobbyState,
+    joinLobby,
+    leaveLobby,
+    startGame,
+  };
 }

--- a/server/src/lobby.rs
+++ b/server/src/lobby.rs
@@ -206,6 +206,9 @@ impl Lobby {
 
 pub fn start_game(&self) {
     *self.game_started.lock() = true;
+    let _ = self.tx.send(Message::Text(
+        serde_json::json!({ "type": "started" }).to_string(),
+    ));
     self.broadcast_lobby_list();
 }
 


### PR DESCRIPTION
## Summary
- broadcast `started` message to lobby clients
- update lobby WebSocket hook for new event
- subscribe to lobby list updates in LobbyView
- disable Start Game until player count is valid and started flag is false

## Testing
- `cargo test --quiet --manifest-path server/Cargo.toml` *(fails: Could not connect to server)*